### PR TITLE
cleanup mythological code

### DIFF
--- a/src/main/kotlin/me/nobaboy/nobaaddons/api/mythological/BurrowAPI.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/api/mythological/BurrowAPI.kt
@@ -115,7 +115,7 @@ object BurrowAPI {
 		return true
 	}
 
-	private fun reset() {
+	fun reset() {
 		burrows.clear()
 		recentlyDugBurrows.clear()
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/api/mythological/DianaAPI.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/api/mythological/DianaAPI.kt
@@ -9,29 +9,29 @@ import me.nobaboy.nobaaddons.utils.InventoryUtils
 import me.nobaboy.nobaaddons.utils.items.ItemUtils.getSkyBlockItem
 import me.nobaboy.nobaaddons.utils.items.ItemUtils.getSkyBlockItemId
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents
+import net.minecraft.client.network.OtherClientPlayerEntity
 import net.minecraft.entity.Entity
 import net.minecraft.entity.player.PlayerEntity
-import net.minecraft.server.network.ServerPlayerEntity
 
 object DianaAPI {
-	private val spade = "ANCESTRAL_SPADE"
+	private const val SPADE = "ANCESTRAL_SPADE"
 
 	fun init() {
 		ServerEntityEvents.ENTITY_LOAD.register { entity, _ -> onEntityLoad(entity) }
 	}
 
 	private fun onEntityLoad(entity: Entity) {
-		if(entity !is ServerPlayerEntity) return
+		if(entity !is OtherClientPlayerEntity) return
 		if(entity.name.string != "Minos Inquisitor") return
 
 		MythologicalEvents.INQUISITOR_SPAWN.invoke(MythologicalEvents.InquisitorSpawn(entity))
 	}
 
-	private fun hasSpadeInHotbar(): Boolean = InventoryUtils.getItemsInHotbar().any { it.getSkyBlockItemId() == spade }
+	private fun hasSpadeInHotbar(): Boolean = InventoryUtils.getItemsInHotbar().any { it.getSkyBlockItemId() == SPADE }
 
 	fun hasSpadeInHand(player: PlayerEntity): Boolean {
 		val heldItem = player.mainHandStack?.getSkyBlockItem() ?: return false
-		return heldItem.id == spade
+		return heldItem.id == SPADE
 	}
 
 	private fun isRitualActive() = MayorAPI.currentMayor.activePerks.contains(MayorPerk.MYTHOLOGICAL_RITUAL) ||

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
@@ -2,12 +2,15 @@ package me.nobaboy.nobaaddons.commands
 
 import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.context.CommandContext
+import me.nobaboy.nobaaddons.api.mythological.BurrowAPI
 import me.nobaboy.nobaaddons.commands.internal.Command
 import me.nobaboy.nobaaddons.commands.internal.CommandUtil
 import me.nobaboy.nobaaddons.commands.internal.Group
 import me.nobaboy.nobaaddons.config.NobaConfigManager
 import me.nobaboy.nobaaddons.features.dungeons.SimonSaysTimer
 import me.nobaboy.nobaaddons.features.events.mythological.BurrowWarpLocations
+import me.nobaboy.nobaaddons.features.events.mythological.BurrowWaypoints
+import me.nobaboy.nobaaddons.features.events.mythological.InquisitorWaypoints
 import me.nobaboy.nobaaddons.features.general.RefillPearls
 import me.nobaboy.nobaaddons.features.qol.MouseLock
 import me.nobaboy.nobaaddons.features.visuals.TemporaryWaypoint
@@ -83,6 +86,15 @@ object NobaCommand : Group("nobaaddons", aliases = listOf("noba"), executeRoot =
 		val resetWarps = Command.command("resetwarps") {
 			executes {
 				BurrowWarpLocations.unlockAll()
+			}
+		}
+
+		val resetBurrows = Command.command("clearburrows") {
+			executes {
+				BurrowAPI.reset()
+				InquisitorWaypoints.reset()
+				BurrowWaypoints.reset()
+				ChatUtils.addMessage("Cleared all waypoints")
 			}
 		}
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/events/skyblock/MythologicalEvents.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/events/skyblock/MythologicalEvents.kt
@@ -3,7 +3,7 @@ package me.nobaboy.nobaaddons.events.skyblock
 import me.nobaboy.nobaaddons.events.internal.EventDispatcher
 import me.nobaboy.nobaaddons.features.events.mythological.BurrowType
 import me.nobaboy.nobaaddons.utils.NobaVec
-import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.client.network.OtherClientPlayerEntity
 
 object MythologicalEvents {
 	@JvmField
@@ -21,5 +21,5 @@ object MythologicalEvents {
 	data class BurrowGuess(val location: NobaVec)
 	data class BurrowFind(val location: NobaVec, val type: BurrowType)
 	data class BurrowDig(val location: NobaVec)
-	data class InquisitorSpawn(val entity: ServerPlayerEntity)
+	data class InquisitorSpawn(val entity: OtherClientPlayerEntity)
 }


### PR DESCRIPTION
- adds a `clearburrows` command as a band-aid fix for frequent ghost mob burrows - this should ideally be properly fixed better later, but I'm not about to try to do that myself.
- use the existing heightmap predicate instead of trying to roll our own (I would've liked to use the existing code for this, but I don't think Hypixel sends the data necessary for that?)
- fix inquisitor waypoints never actually being created because of an incorrect `is` check on `ServerPlayerEntity`, which is - in fact - not used by the client on a multiplayer server.