### PR TITLE
Add Discord announcement to release workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,14 +13,6 @@ ij_any_space_before_while_parentheses = false
 ij_any_space_before_try_parentheses = false
 ij_any_space_before_catch_parentheses = false
 
-[*.md]
-indent_style = space
-indent_size = 2
-
-[*.properties]
-indent_style = space
-indent_size = 2
-
-[*.json]
+[{*.json,*.yml,*.properties,*.md}]
 indent_style = space
 indent_size = 2

--- a/.github/announce_release.py
+++ b/.github/announce_release.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import requests
+from pathlib import Path
+import os
+from typing import Iterator
+
+CHANGELOG = ""
+VERSION = ""
+mc_versions = os.listdir("versions")
+
+with open(Path(__file__).parent.parent / "gradle.properties") as f:
+    for line in f.readlines():
+        if line.startswith("mod.version="):
+            VERSION = line.replace("mod.version=", "").strip()
+            break
+    else:
+        raise RuntimeError("Couldn't find mod.version property!")
+
+with open(Path(__file__).parent.parent / "CHANGELOG.mini") as f:
+    CHANGELOG = f.read()
+
+versions = "\n".join(
+    f"- [{x}](<https://modrinth.com/mod/nobaaddons/version/{VERSION}+{x}>)"
+    for x in mc_versions
+)
+
+
+# The following function is taken from Red and modified to remove behaviour we don't need
+# https://github.com/Cog-Creators/Red-DiscordBot/blob/ad6b8662b2/redbot/core/utils/chat_formatting.py#L235-L305
+def pagify(
+    text: str,
+    delims=None,
+    *,
+    priority: bool = False,
+    shorten_by: int = 8,
+    page_length: int = 2000,
+) -> Iterator[str]:
+    if delims is None:
+        delims = ["\n"]
+
+    in_text = text
+    page_length -= shorten_by
+    while len(in_text) > page_length:
+        closest_delim = (in_text.rfind(d, 1, page_length) for d in delims)
+        if priority:
+            closest_delim = next((x for x in closest_delim if x > 0), -1)
+        else:
+            closest_delim = max(closest_delim)
+        closest_delim = closest_delim if closest_delim != -1 else page_length
+        to_send = in_text[:closest_delim]
+        if len(to_send.strip()) > 0:
+            yield to_send
+        in_text = in_text[closest_delim:]
+
+    if len(in_text.strip()) > 0:
+        yield in_text
+
+
+message = f"""
+# `{VERSION}` has been released
+
+<:modrinth:1040805511538421890> **Download from Modrinth:**
+{versions}
+
+# Changelog
+
+{CHANGELOG}
+""".strip()
+
+
+if os.environ.get("DRY_RUN"):
+    print(message)
+    exit(0)
+
+
+WEBHOOK = os.environ["DISCORD_WEBHOOK"]
+
+for page in pagify(message):
+    requests.post(
+        f"{WEBHOOK}?wait=true",
+        json={
+            "content": page,
+            "allowed_mentions": {"parse": []}
+        },
+        headers={"Content-Type": "application/json"},
+    )

--- a/.github/announce_release.py
+++ b/.github/announce_release.py
@@ -10,51 +10,51 @@ VERSION = ""
 mc_versions = os.listdir("versions")
 
 with open(Path(__file__).parent.parent / "gradle.properties") as f:
-    for line in f.readlines():
-        if line.startswith("mod.version="):
-            VERSION = line.replace("mod.version=", "").strip()
-            break
-    else:
-        raise RuntimeError("Couldn't find mod.version property!")
+	for line in f.readlines():
+		if line.startswith("mod.version="):
+			VERSION = line.replace("mod.version=", "").strip()
+			break
+	else:
+		raise RuntimeError("Couldn't find mod.version property!")
 
 with open(Path(__file__).parent.parent / "CHANGELOG.mini") as f:
-    CHANGELOG = f.read()
+	CHANGELOG = f.read()
 
 versions = "\n".join(
-    f"- [{x}](<https://modrinth.com/mod/nobaaddons/version/{VERSION}+{x}>)"
-    for x in mc_versions
+	f"- [{x}](<https://modrinth.com/mod/nobaaddons/version/{VERSION}+{x}>)"
+	for x in mc_versions
 )
 
 
 # The following function is taken from Red and modified to remove behaviour we don't need
 # https://github.com/Cog-Creators/Red-DiscordBot/blob/ad6b8662b2/redbot/core/utils/chat_formatting.py#L235-L305
 def pagify(
-    text: str,
-    delims=None,
-    *,
-    priority: bool = False,
-    shorten_by: int = 8,
-    page_length: int = 2000,
+	text: str,
+	delims=None,
+	*,
+	priority: bool = False,
+	shorten_by: int = 8,
+	page_length: int = 2000,
 ) -> Iterator[str]:
-    if delims is None:
-        delims = ["\n"]
+	if delims is None:
+		delims = ["\n"]
 
-    in_text = text
-    page_length -= shorten_by
-    while len(in_text) > page_length:
-        closest_delim = (in_text.rfind(d, 1, page_length) for d in delims)
-        if priority:
-            closest_delim = next((x for x in closest_delim if x > 0), -1)
-        else:
-            closest_delim = max(closest_delim)
-        closest_delim = closest_delim if closest_delim != -1 else page_length
-        to_send = in_text[:closest_delim]
-        if len(to_send.strip()) > 0:
-            yield to_send
-        in_text = in_text[closest_delim:]
+	in_text = text
+	page_length -= shorten_by
+	while len(in_text) > page_length:
+		closest_delim = (in_text.rfind(d, 1, page_length) for d in delims)
+		if priority:
+			closest_delim = next((x for x in closest_delim if x > 0), -1)
+		else:
+			closest_delim = max(closest_delim)
+		closest_delim = closest_delim if closest_delim != -1 else page_length
+		to_send = in_text[:closest_delim]
+		if len(to_send.strip()) > 0:
+			yield to_send
+		in_text = in_text[closest_delim:]
 
-    if len(in_text.strip()) > 0:
-        yield in_text
+	if len(in_text.strip()) > 0:
+		yield in_text
 
 
 message = f"""
@@ -70,18 +70,18 @@ message = f"""
 
 
 if os.environ.get("DRY_RUN"):
-    print(message)
-    exit(0)
+	print(message)
+	exit(0)
 
 
 WEBHOOK = os.environ["DISCORD_WEBHOOK"]
 
 for page in pagify(message):
-    requests.post(
-        f"{WEBHOOK}?wait=true",
-        json={
-            "content": page,
-            "allowed_mentions": {"parse": []}
-        },
-        headers={"Content-Type": "application/json"},
-    )
+	requests.post(
+		f"{WEBHOOK}?wait=true",
+		json={
+			"content": page,
+			"allowed_mentions": {"parse": []}
+		},
+		headers={"Content-Type": "application/json"},
+	)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/wrapper-validation-action@v3
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -26,7 +28,9 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       - name: Execute Gradle build
         run: ./gradlew chiseledBuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/wrapper-validation-action@v3
 
       - name: Setup Java 21
         uses: actions/setup-java@v4
@@ -24,7 +26,17 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
+
       - name: Release
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew chiseledPublishMods
+
+      - name: Announce in Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: python3 .github/announce_release.py

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ replay_*.log
 # kotlin
 
 .kotlin/
+
+# release process
+
+CHANGELOG.mini


### PR DESCRIPTION
Also updated action step versions

This script was chosen over using the [existing Discord webhook option](https://modmuss50.github.io/mod-publish-plugin/platforms/discord/) in `mod-publish-plugin` to be able to combine all the relevant versions into one message, instead of each released version sending its own message

Note that this requires a relevant `DISCORD_WEBHOOK` repository secret to be added to work