### PR TITLE
Add config option requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Chat Notifications - celeste
 - Item Pickup Log - celeste
+- Worm Alert - nobaboy
 - `/noba day` to display the lobby day count (since Hypixel doesn't send the information for the line F3 shows this on) - celeste
 
 ### Changed
@@ -23,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `/noba refill pearls` using the wrong item ID - celeste
+- `/noba refill item` is now case-insensitive to match `/gfs` - celeste
 - An occasional crash that occurs while processing an event - celeste
 
 ## 0.1.0-Alpha.12 - 2024-12-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Added `/noba gui` as an alias to `/noba hud` - celeste
 - Reworked commands to use [commander](https://github.com/celestialfault/commander) - celeste
+- Reworked the main mod config to not depend on YACL - nobaboy
+- The config UI will now clearly mark options unavailable if the feature they're associated with isn't enabled - celeste
 - Rewrote the HUD internals to make adding new elements easier - celeste
 - Changed how HUD elements render to properly handle different window sizes - celeste
   - This will cause existing info boxes to be in the top left corner when updating
+
+### Fixed
+
+- An occasional crash that occurs while processing an event - celeste
 
 ## 0.1.0-Alpha.12 - 2024-12-29
 

--- a/src/main/java/me/nobaboy/nobaaddons/mixins/accessors/AbstractConfigAccessor.java
+++ b/src/main/java/me/nobaboy/nobaaddons/mixins/accessors/AbstractConfigAccessor.java
@@ -1,0 +1,12 @@
+package me.nobaboy.nobaaddons.mixins.accessors;
+
+import dev.celestialfault.celestialconfig.AbstractConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.nio.file.Path;
+
+@Mixin(AbstractConfig.class)
+public interface AbstractConfigAccessor {
+	@Invoker Path callGetPath();
+}

--- a/src/main/java/me/nobaboy/nobaaddons/mixins/accessors/AbstractConfigAccessor.java
+++ b/src/main/java/me/nobaboy/nobaaddons/mixins/accessors/AbstractConfigAccessor.java
@@ -8,5 +8,5 @@ import java.nio.file.Path;
 
 @Mixin(AbstractConfig.class)
 public interface AbstractConfigAccessor {
-	@Invoker Path callGetPath();
+	@Invoker(remap = false) Path callGetPath();
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
@@ -23,6 +23,7 @@ import me.nobaboy.nobaaddons.api.skyblock.events.mythological.DianaAPI
 import me.nobaboy.nobaaddons.commands.NobaCommand
 import me.nobaboy.nobaaddons.commands.SWikiCommand
 import me.nobaboy.nobaaddons.config.NobaConfig
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.config.UISettings
 import me.nobaboy.nobaaddons.core.UpdateNotifier
 import me.nobaboy.nobaaddons.data.PersistentCache
@@ -112,10 +113,10 @@ object NobaAddons : ClientModInitializer {
 	// immediately ran).
 	override fun onInitializeClient() {
 		/* region Core */
-		NobaConfig.init()
-		PersistentCache.init()
+		NobaConfig.INSTANCE.safeLoad()
+		PersistentCache.safeLoad()
 		RepoManager.init()
-		UISettings.init()
+		UISettings.safeLoad()
 		UIManager.init()
 
 		UpdateNotifier.init()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
@@ -114,9 +114,9 @@ object NobaAddons : ClientModInitializer {
 	override fun onInitializeClient() {
 		/* region Core */
 		NobaConfig.INSTANCE.safeLoad()
-		PersistentCache.safeLoad()
+		PersistentCache.init()
 		RepoManager.init()
-		UISettings.safeLoad()
+		UISettings.init()
 		UIManager.init()
 
 		UpdateNotifier.init()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
@@ -46,7 +46,7 @@ object NobaCommand {
 		NobaConfig.getConfigScreen(null).queueOpen()
 	}
 
-	@Command
+	@Command("hud", "gui")
 	fun hud() {
 		NobaHudScreen(null).queueOpen()
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
@@ -78,7 +78,7 @@ object NobaCommand {
 			return
 		}
 		TemporaryWaypoints.addWaypoint(x, y, z, "Temporary Waypoint")
-		ChatUtils.addMessage(tr("nobaaddons.temporaryWaypoint.createdFromCommand", "Added a waypoint at $x, $y, $z. This waypoint will last until you walk near it."))
+		ChatUtils.addMessage(tr("nobaaddons.temporaryWaypoint.createdFromCommand", "Added a waypoint at $x, $y, $z. This waypoint will not disappear until you walk near it."))
 	}
 
 	@Command

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/ModMenuImpl.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/ModMenuImpl.kt
@@ -5,5 +5,5 @@ import com.terraformersmc.modmenu.api.ModMenuApi
 import me.nobaboy.nobaaddons.screens.NobaMainScreen
 
 class ModMenuImpl : ModMenuApi {
-	override fun getModConfigScreenFactory() = ConfigScreenFactory { NobaMainScreen(it) }
+	override fun getModConfigScreenFactory() = ConfigScreenFactory(::NobaMainScreen)
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
@@ -3,19 +3,17 @@ package me.nobaboy.nobaaddons.config
 import dev.celestialfault.celestialconfig.AbstractConfig
 import dev.celestialfault.celestialconfig.migrations.Migrations
 import dev.isxander.yacl3.api.YetAnotherConfigLib
-import kotlinx.io.IOException
 import me.nobaboy.nobaaddons.NobaAddons
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.config.categories.*
 import me.nobaboy.nobaaddons.config.configs.*
 import me.nobaboy.nobaaddons.utils.CommonText
 import net.minecraft.client.gui.screen.Screen
-import java.text.SimpleDateFormat
-import java.util.Date
 
 /*
- * Migrations MUST be added at the end of this block, otherwise they will NOT run. Executed migrations are
- * skipped, so new changes must be added as separate migrations. Removing pre-existing migrations is NOT supported
- * and will cause player configs to completely break, so avoid doing so.
+ * Migrations MUST be added at the end of this block, otherwise they will NOT run. Migrations that have already been
+ * applied are skipped, so new changes must be added as separate migrations. Removing pre-existing migrations is
+ * NOT supported and will cause player configs to completely break, so avoid doing so.
  */
 private val migrations = Migrations.create {
 	add(migration = ::`001_removeYaclVersion`)
@@ -42,25 +40,7 @@ class NobaConfig private constructor() : AbstractConfig(CONFIG_PATH, migrations 
 		val INSTANCE = NobaConfig()
 
 		fun init() {
-			try {
-				INSTANCE.load()
-			} catch(ex: IOException) {
-				val configPath = NobaAddons.CONFIG_DIR.resolve("config.json")
-
-				val dateFormatter = SimpleDateFormat("yyyy-MM-dd")
-				val date = dateFormatter.format(Date())
-
-				val backupFileName = generateSequence(1) { it + 1 }
-					.map { "config-$date-$it.json.bak" }
-					.first { !configPath.resolveSibling(it).toFile().exists() }
-
-				val backupFile = configPath.resolveSibling(backupFileName).toFile()
-
-				NobaAddons.LOGGER.error("Failed to load config", ex)
-				if(configPath.toFile().renameTo(backupFile)) {
-					NobaAddons.LOGGER.error("Config file has been moved to $backupFile")
-				}
-			}
+			INSTANCE.safeLoad()
 		}
 
 		fun getConfigScreen(parent: Screen?): Screen {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
@@ -4,7 +4,6 @@ import dev.celestialfault.celestialconfig.AbstractConfig
 import dev.celestialfault.celestialconfig.migrations.Migrations
 import dev.isxander.yacl3.api.YetAnotherConfigLib
 import me.nobaboy.nobaaddons.NobaAddons
-import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.config.categories.*
 import me.nobaboy.nobaaddons.config.configs.*
 import me.nobaboy.nobaaddons.utils.CommonText
@@ -38,10 +37,6 @@ class NobaConfig private constructor() : AbstractConfig(CONFIG_PATH, migrations 
 	companion object {
 		@JvmField
 		val INSTANCE = NobaConfig()
-
-		fun init() {
-			INSTANCE.safeLoad()
-		}
 
 		fun getConfigScreen(parent: Screen?): Screen {
 			val defaults = NobaConfig()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
@@ -28,6 +28,7 @@ import me.nobaboy.nobaaddons.mixins.accessors.AbstractConfigAccessor
 import me.nobaboy.nobaaddons.utils.ErrorManager
 import me.nobaboy.nobaaddons.utils.NobaColor
 import me.nobaboy.nobaaddons.utils.NobaColor.Companion.toNobaColor
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.minecraft.text.Text
 import net.minecraft.util.PathUtil
 import net.minecraft.util.TranslatableOption
@@ -60,6 +61,19 @@ object NobaConfigUtils {
 				NobaAddons.LOGGER.warn("Moved config file to $backup")
 			} else {
 				NobaAddons.LOGGER.warn("Couldn't rename config file")
+			}
+		}
+	}
+
+	/**
+	 * Attaches a [ClientLifecycleEvents] listener for when the client is stopping which calls [AbstractConfig.save]
+	 */
+	fun AbstractConfig.saveOnExit() {
+		ClientLifecycleEvents.CLIENT_STOPPING.register {
+			try {
+				save()
+			} catch(ex: Throwable) {
+				NobaAddons.LOGGER.error("Failed to automatically save $this", ex)
 			}
 		}
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
@@ -40,7 +40,7 @@ import kotlin.io.path.nameWithoutExtension
 import kotlin.reflect.KMutableProperty
 
 object NobaConfigUtils {
-	private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss", Locale.ROOT)
+	private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
 
 	fun AbstractConfig.safeLoad(pathSupplier: AbstractConfig.() -> Path = { (this as AbstractConfigAccessor).callGetPath() }) {
 		try {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
@@ -74,7 +74,7 @@ object NobaConfigUtils {
 			try {
 				save()
 			} catch(ex: Throwable) {
-				NobaAddons.LOGGER.error("Failed to automatically save $this", ex)
+				NobaAddons.LOGGER.error("Failed to automatically save ${this::class.simpleName}", ex)
 			}
 		}
 	}
@@ -85,7 +85,7 @@ object NobaConfigUtils {
 	fun AbstractConfig.saveEvery(ticks: Int) {
 		Scheduler.scheduleAsync(ticks, repeat = true) {
 			if(dirty) {
-				NobaAddons.LOGGER.info("Auto-saving ${this@saveEvery}")
+				NobaAddons.LOGGER.info("Auto-saving ${this@saveEvery::class.simpleName}")
 				save()
 			}
 		}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
@@ -42,6 +42,9 @@ import kotlin.reflect.KMutableProperty
 object NobaConfigUtils {
 	private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
 
+	/**
+	 * Attempts to load the provided [AbstractConfig], logging an error and renaming the config file if it fails.
+	 */
 	fun AbstractConfig.safeLoad(pathSupplier: AbstractConfig.() -> Path = { (this as AbstractConfigAccessor).callGetPath() }) {
 		try {
 			load()
@@ -112,6 +115,7 @@ object NobaConfigUtils {
 	}
 
 	fun createLabelController(vararg lines: Text): LabelOption.Builder {
+		require(lines.isNotEmpty()) { "Cannot create an empty label controller" }
 		return LabelOption.createBuilder().apply {
 			if(lines.size == 1) line(lines[0]) else lines(lines.toList())
 		}
@@ -127,15 +131,13 @@ object NobaConfigUtils {
 		description: Text? = null,
 		collapsed: Boolean = true,
 		crossinline builder: OptionGroup.Builder.() -> Unit
-	): ConfigCategory.Builder {
+	) {
 		group(OptionGroup.createBuilder()
 			.name(name)
 			.also { if(description != null) it.description(OptionDescription.of(description)) }
 			.also { builder(it) }
 			.collapsed(collapsed)
 			.build())
-
-		return this
 	}
 
 	fun <G : OptionAddable, T : Any> G.add(

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfigUtils.kt
@@ -28,6 +28,7 @@ import me.nobaboy.nobaaddons.mixins.accessors.AbstractConfigAccessor
 import me.nobaboy.nobaaddons.utils.ErrorManager
 import me.nobaboy.nobaaddons.utils.NobaColor
 import me.nobaboy.nobaaddons.utils.NobaColor.Companion.toNobaColor
+import me.nobaboy.nobaaddons.utils.Scheduler
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.minecraft.text.Text
 import net.minecraft.util.PathUtil
@@ -44,7 +45,7 @@ object NobaConfigUtils {
 	private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
 
 	/**
-	 * Attempts to load the provided [AbstractConfig], logging an error and renaming the config file if it fails.
+	 * Attempts to load the associated [AbstractConfig], logging an error and renaming the config file if it fails.
 	 */
 	fun AbstractConfig.safeLoad(pathSupplier: AbstractConfig.() -> Path = { (this as AbstractConfigAccessor).callGetPath() }) {
 		try {
@@ -74,6 +75,18 @@ object NobaConfigUtils {
 				save()
 			} catch(ex: Throwable) {
 				NobaAddons.LOGGER.error("Failed to automatically save $this", ex)
+			}
+		}
+	}
+
+	/**
+	 * Attempts to save the associated [AbstractConfig] every [ticks] interval if any changes have been made
+	 */
+	fun AbstractConfig.saveEvery(ticks: Int) {
+		Scheduler.scheduleAsync(ticks, repeat = true) {
+			if(dirty) {
+				NobaAddons.LOGGER.info("Auto-saving ${this@saveEvery}")
+				save()
 			}
 		}
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/UISettings.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/UISettings.kt
@@ -2,8 +2,8 @@ package me.nobaboy.nobaaddons.config
 
 import dev.celestialfault.celestialconfig.AbstractConfig
 import me.nobaboy.nobaaddons.NobaAddons
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.ui.data.TextElement
-import me.nobaboy.nobaaddons.utils.ErrorManager
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import java.io.IOException
 
@@ -11,12 +11,7 @@ object UISettings : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("ui.json")) {
 	val itemPickupLog by TextElement("itemPickupLog")
 
 	fun init() {
-		try {
-			load()
-		} catch(ex: IOException) {
-			ErrorManager.logError("Failed to load UI settings", ex)
-		}
-
+		safeLoad()
 		ClientLifecycleEvents.CLIENT_STOPPING.register {
 			try {
 				save()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/UISettings.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/UISettings.kt
@@ -3,23 +3,14 @@ package me.nobaboy.nobaaddons.config
 import dev.celestialfault.celestialconfig.AbstractConfig
 import me.nobaboy.nobaaddons.NobaAddons
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.saveOnExit
 import me.nobaboy.nobaaddons.ui.data.TextElement
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
-import java.io.IOException
 
 object UISettings : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("ui.json")) {
 	val itemPickupLog by TextElement("itemPickupLog")
 
 	fun init() {
 		safeLoad()
-		ClientLifecycleEvents.CLIENT_STOPPING.register {
-			try {
-				save()
-			} catch(ex: IOException) {
-				// Using ErrorManager here is largely pointless, as the chat won't exist to see the error message in,
-				// so just print it directly to the logs.
-				NobaAddons.LOGGER.error("Failed to save UI settings", ex)
-			}
-		}
+		saveOnExit()
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/ChatCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/ChatCategory.kt
@@ -6,6 +6,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.cycler
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.core.Rarity
 import me.nobaboy.nobaaddons.core.Rarity.Companion.toArray
 import me.nobaboy.nobaaddons.utils.CommonText
@@ -166,7 +167,7 @@ object ChatCategory {
 			val warpOutTitle = tr("nobaaddons.config.chat.chatCommands.warpOut", "!warpout Command")
 			val warpOutDescription = tr("nobaaddons.config.chat.chatCommands.warpOut.tooltip", "Warps the specified player to your lobby when used")
 
-			boolean(
+			val dmEnabled = boolean(
 				CommonText.Config.ENABLED,
 				tr("nobaaddons.config.chat.chatCommands.dm.enabled.tooltip", "Enables chat commands when other players /msg you"),
 				default = defaults.chat.chatCommands.dm.enabled,
@@ -176,30 +177,30 @@ object ChatCategory {
 				helpTitle, helpDescription,
 				default = defaults.chat.chatCommands.dm.help,
 				property = config.chat.chatCommands.dm::help
-			)
+			) requires dmEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.dm.warpMe", "!warpme Command"),
 				tr("nobaaddons.config.chat.chatCommands.dm.warpMe.tooltip", "Warps the messaging player to your lobby"),
 				default = defaults.chat.chatCommands.dm.warpMe,
 				property = config.chat.chatCommands.dm::warpMe
-			)
+			) requires dmEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.dm.partyMe", "!partyme Command"),
 				tr("nobaaddons.config.chat.chatCommands.dm.partyMe.tooltip", "Invites the messaging player to your party"),
 				default = defaults.chat.chatCommands.dm.partyMe,
 				property = config.chat.chatCommands.dm::partyMe
-			)
+			) requires dmEnabled
 			boolean(
 				warpOutTitle, warpOutDescription,
 				default = defaults.chat.chatCommands.dm.warpOut,
 				property = config.chat.chatCommands.dm::warpOut
-			)
+			) requires dmEnabled
 			// endregion
 
 			// region Party
 			label(tr("nobaaddons.config.chat.chatCommands.label.party", "Party Commands"))
 
-			boolean(
+			val partyEnabled = boolean(
 				CommonText.Config.ENABLED,
 				tr("nobaaddons.config.chat.chatCommands.party.enabled.tooltip", "Enables chat commands in party chat"),
 				default = defaults.chat.chatCommands.party.enabled,
@@ -209,37 +210,37 @@ object ChatCategory {
 				helpTitle, helpDescription,
 				default = defaults.chat.chatCommands.party.help,
 				property = config.chat.chatCommands.party::help
-			)
+			) requires partyEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.party.allInvite", "!allinvite Command"),
 				tr("nobaaddons.config.chat.chatCommands.party.allInvite.tooltip", "Runs '/p settings allinvite' when used if you're the party leader"),
 				default = defaults.chat.chatCommands.party.allInvite,
 				property = config.chat.chatCommands.party::allInvite
-			)
+			) requires partyEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.party.transfer", "!transfer Command"),
 				tr("nobaaddons.config.chat.chatCommands.party.transfer.tooltip", "Transfers the party to the player using the command (or the specified player, if any) if you're the party leader"),
 				default = defaults.chat.chatCommands.party.transfer,
 				property = config.chat.chatCommands.party::transfer
-			)
+			) requires partyEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.party.warp", "!warp Command"),
 				tr("nobaaddons.config.chat.chatCommands.party.warp.tooltip", "Warps the party to your current lobby (with an optional seconds delay) if you're the leader"),
 				default = defaults.chat.chatCommands.party.warp,
 				property = config.chat.chatCommands.party::warp
-			)
+			) requires partyEnabled
 			boolean(
 				tr("nobaaddons.config.chat.chatCommands.party.coords", "!coords Command"),
 				tr("nobaaddons.config.chat.chatCommands.party.coords.tooltip", "Responds with your current in-game coordinates"),
 				default = defaults.chat.chatCommands.party.coords,
 				property = config.chat.chatCommands.party::coords
-			)
+			) requires partyEnabled
 			// endregion
 
 			// region Guild
 			label(tr("nobaaddons.config.chat.chatCommands.label.guild", "Guild Command"))
 
-			boolean(
+			val guildEnabled = boolean(
 				CommonText.Config.ENABLED,
 				tr("nobaaddons.config.chat.chatCommands.guild.enabled.tooltip", "Enables chat commands in guild chat"),
 				default = defaults.chat.chatCommands.guild.enabled,
@@ -249,12 +250,12 @@ object ChatCategory {
 				helpTitle, helpDescription,
 				default = defaults.chat.chatCommands.guild.help,
 				property = config.chat.chatCommands.guild::help
-			)
+			) requires guildEnabled
 			boolean(
 				warpOutTitle, warpOutDescription,
 				default = defaults.chat.chatCommands.guild.warpOut,
 				property = config.chat.chatCommands.guild::warpOut
-			)
+			) requires guildEnabled
 			// endregion
 		}
 		// endregion

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/DungeonsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/DungeonsCategory.kt
@@ -6,6 +6,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.cycler
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.utils.CommonText
 import me.nobaboy.nobaaddons.utils.tr
 
@@ -13,7 +14,7 @@ object DungeonsCategory {
 	fun create(defaults: NobaConfig, config: NobaConfig) = NobaConfigUtils.buildCategory(tr("nobaaddons.config.dungeons", "Dungeons")) {
 		// region Highlight Starred Mobs
 		buildGroup(tr("nobaaddons.config.dungeons.highlightStarredMobs", "Highlight Starred Mobs")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.dungeons.highlightStarredMobs.enabled,
 				property = config.dungeons.highlightStarredMobs::enabled
@@ -22,18 +23,18 @@ object DungeonsCategory {
 				CommonText.Config.HIGHLIGHT_COLOR,
 				default = defaults.dungeons.highlightStarredMobs.highlightColor,
 				property = config.dungeons.highlightStarredMobs::highlightColor
-			)
+			) requires enabled
 			cycler(
 				tr("nobaaddons.config.dungeons.highlightStarredMobs.highlightMode", "Highlight Mode"),
 				default = defaults.dungeons.highlightStarredMobs.highlightMode,
 				property = config.dungeons.highlightStarredMobs::highlightMode
-			)
+			) requires enabled
 		}
 		// endregion
 
 		// region Simon Says Timer
 		buildGroup(tr("nobaaddons.config.dungeons.simonSaysTimer", "Simon Says Timer")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.dungeons.simonSaysTimer.enabled,
 				property = config.dungeons.simonSaysTimer::enabled
@@ -43,7 +44,7 @@ object DungeonsCategory {
 				tr("nobaaddons.config.dungeons.simonSaysTimer.timeInPartyChat.tooltip", "Sends your Simon Says device completion time in party chat"),
 				default = defaults.dungeons.simonSaysTimer.timeInPartyChat,
 				property = config.dungeons.simonSaysTimer::timeInPartyChat
-			)
+			) requires enabled
 		}
 		// endregion
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/EventsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/EventsCategory.kt
@@ -6,6 +6,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.cycler
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.utils.CommonText
 import me.nobaboy.nobaaddons.utils.tr
 
@@ -13,14 +14,14 @@ object EventsCategory {
 	fun create(defaults: NobaConfig, config: NobaConfig) = NobaConfigUtils.buildCategory(tr("nobaaddons.config.events", "Events")) {
 		// region Mythological Ritual
 		buildGroup(tr("nobaaddons.config.events.mythological", "Mythological Ritual")) {
-			boolean(
+			val burrowGuess = boolean(
 				tr("nobaaddons.config.events.mythological.burrowGuess", "Burrow Guess"),
 				tr("nobaaddons.config.events.mythological.burrowGuess.tooltip", "Guesses the next burrow location from the Ancestral Spade's Echo ability"),
 				default = defaults.events.mythological.burrowGuess,
 				property = config.events.mythological::burrowGuess
 			)
-			boolean(
-				tr("nobaaddons.config.events.mythological.findNearbyBurrows", "Find Nearby Burros"),
+			val findNearby = boolean(
+				tr("nobaaddons.config.events.mythological.findNearbyBurrows", "Find Nearby Burrows"),
 				tr("nobaaddons.config.events.mythological.findNearbyBurrows.tooltip", "Highlights nearby burrows with a waypoint"),
 				default = defaults.events.mythological.findNearbyBurrows,
 				property = config.events.mythological::findNearbyBurrows
@@ -30,14 +31,14 @@ object EventsCategory {
 				tr("nobaaddons.config.events.mythological.pingOnBurrowFind.tooltip", "Plays a sound when a burrow is found nearby"),
 				default = defaults.events.mythological.dingOnBurrowFind,
 				property = config.events.mythological::dingOnBurrowFind
-			)
+			) requires findNearby
 			boolean(
 				tr("nobaaddons.config.events.mythological.removeGuessOnBurrowFind", "Hide Guess Near Burrows"),
 				tr("nobaaddons.config.events.mythological.removeGuessOnBurrowFind.tooltip", "Automatically hides any guesses when nearby burrows are found"),
 				default = defaults.events.mythological.removeGuessOnBurrowFind,
 				property = config.events.mythological::removeGuessOnBurrowFind
-			)
-			boolean(
+			) requires listOf(findNearby, burrowGuess)
+			val warp = boolean(
 				tr("nobaaddons.config.events.mythological.findNearestWarp", "Find Nearest Warp"),
 				tr("nobaaddons.config.events.mythological.findNearestWarp.tooltip", "Finds the nearest /warp to the guess, which can automatically be warped to with the associated key configured in Controls"),
 				default = defaults.events.mythological.findNearestWarp,
@@ -46,7 +47,7 @@ object EventsCategory {
 
 			label(tr("nobaaddons.config.events.mythological.label.inquisitorSharing", "Inquisitor Sharing"))
 
-			boolean(
+			val alertInquis = boolean(
 				tr("nobaaddons.config.events.mythological.alertInquisitor", "Alert Inquisitor"),
 				tr("nobaaddons.config.events.mythological.alertInquisitor.tooltip", "Send a message in chat when you find a Minos Inquisitor"),
 				default = defaults.events.mythological.alertInquisitor,
@@ -57,24 +58,24 @@ object EventsCategory {
 				tr("nobaaddons.config.events.mythological.alertOnlyInParty.tooltip", "The Inquisitor alert message will always be sent in party chat, instead of your current selected /chat"),
 				default = defaults.events.mythological.alertOnlyInParty,
 				property = config.events.mythological::alertOnlyInParty
-			)
+			) requires alertInquis
 			cycler(
 				CommonText.Config.NOTIFICATION_SOUND,
 				default = defaults.events.mythological.notificationSound,
 				property = config.events.mythological::notificationSound
-			)
+			) requires alertInquis
 			boolean(
 				tr("nobaaddons.config.events.mythological.showInquisitorDespawnTime", "Show Inquisitor Despawn Time"),
 				tr("nobaaddons.config.events.mythological.showInquisitorDespawnTime.tooltip", "Displays how much time is left until the Minos Inquisitor despawns"),
 				default = defaults.events.mythological.showInquisitorDespawnTime,
 				property = config.events.mythological::showInquisitorDespawnTime
-			)
+			) requires alertInquis
 			boolean(
 				tr("nobaaddons.config.events.mythological.inquisitorFocusMode", "Inquisitor Focus Mode"),
 				tr("nobaaddons.config.events.mythological.inquisitorFocusMode.tooltip", "Hides all other waypoints when an Inquisitor spawn is detected"),
 				default = defaults.events.mythological.inquisitorFocusMode,
 				property = config.events.mythological::inquisitorFocusMode
-			)
+			) requires alertInquis
 
 			label(CommonText.Config.LABEL_MISC)
 
@@ -92,19 +93,19 @@ object EventsCategory {
 				tr("nobaaddons.config.events.mythological.ignoreCrypt.tooltip", "Because leaving the crypts may be inconvenient"),
 				default = defaults.events.mythological.ignoreCrypt,
 				property = config.events.mythological::ignoreCrypt
-			)
+			) requires warp
 			boolean(
 				tr("nobaaddons.config.events.mythological.ignoreWizard", "Ignore /warp wizard"),
 				tr("nobaaddons.config.events.mythological.ignoreWizard.tooltip", "Because it's easy to accidentally fall into the Rift from it"),
 				default = defaults.events.mythological.ignoreWizard,
 				property = config.events.mythological::ignoreWizard
-			)
+			) requires warp
 			boolean(
 				tr("nobaaddons.config.events.mythological.ignoreStonks", "Ignore /warp stonks"),
 				tr("nobaaddons.config.events.mythological.ignoreStonks.tooltip", "Because it's new"),
 				default = defaults.events.mythological.ignoreStonks,
 				property = config.events.mythological::ignoreStonks
-			)
+			) requires warp
 		}
 		// endregion
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
@@ -18,6 +18,14 @@ import net.minecraft.text.Text
 
 object FishingCategory {
 	fun create(defaults: NobaConfig, config: NobaConfig) = NobaConfigUtils.buildCategory(tr("nobaaddons.config.fishing", "Fishing")) {
+		boolean(
+			tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing", "Hide Other People Fishing"),
+			tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing.tooltip", "Hides the fishing bobber of other players"),
+			// TODO move this to fishing in config, I don't feel like writing a migration for this right now
+			default = defaults.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing,
+			property = config.uiAndVisuals.renderingTweaks::hideOtherPeopleFishing
+		)
+
 		// region Bobber Timer
 		buildGroup(tr("nobaaddons.config.fishing.bobberTimer", "Bobber Timer")) {
 			val enabled = boolean(

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
@@ -6,6 +6,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.cycler
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.core.Rarity
 import me.nobaboy.nobaaddons.core.Rarity.Companion.toArray
 import me.nobaboy.nobaaddons.core.fishing.TrophyFishRarity
@@ -19,7 +20,7 @@ object FishingCategory {
 	fun create(defaults: NobaConfig, config: NobaConfig) = NobaConfigUtils.buildCategory(tr("nobaaddons.config.fishing", "Fishing")) {
 		// region Bobber Timer
 		buildGroup(tr("nobaaddons.config.fishing.bobberTimer", "Bobber Timer")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.fishing.bobberTimer.enabled,
 				property = config.fishing.bobberTimer::enabled
@@ -28,7 +29,7 @@ object FishingCategory {
 				tr("nobaaddons.config.fishing.bobberTimer.crimsonIsleOnly", "Show on Crimson Isle Only"),
 				default = defaults.fishing.bobberTimer.crimsonIsleOnly,
 				property = config.fishing.bobberTimer::crimsonIsleOnly
-			)
+			) requires enabled
 		}
 		// endregion
 
@@ -47,7 +48,7 @@ object FishingCategory {
 
 		// region Sea Creature Alert
 		buildGroup(tr("nobaaddons.config.fishing.seaCreatureAlert", "Sea Creature Alert")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.fishing.seaCreatureAlert.enabled,
 				property = config.fishing.seaCreatureAlert::enabled
@@ -57,37 +58,37 @@ object FishingCategory {
 				tr("nobaaddons.config.fishing.seaCreatureAlert.nameInsteadOfRarity.tooltip", "Uses the sea creature's name instead when displaying the notification, instead of 'Legendary Catch!'"),
 				default = defaults.fishing.seaCreatureAlert.nameInsteadOfRarity,
 				property = config.fishing.seaCreatureAlert::nameInsteadOfRarity
-			)
+			) requires enabled
 			cycler(
 				tr("nobaaddons.config.fishing.seaCreatureAlert.minimumRarity", "Minimum Rarity"),
 				tr("nobaaddons.config.fishing.seaCreatureAlert.minimumRarity.tooltip", "The minimum rarity to display a catch notification for"),
 				default = defaults.fishing.seaCreatureAlert.minimumRarity,
 				property = config.fishing.seaCreatureAlert::minimumRarity,
 				onlyInclude = (Rarity.COMMON..Rarity.MYTHIC).toArray()
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.fishing.seaCreatureAlert.carrotKingIsRare", "Carrot King is Rare"),
 				tr("nobaaddons.config.fishing.seaCreatureAlert.carrotKingIsRare.tooltip", "Carrot King will be considered rare even if the above minimum rarity isn't low enough for it (since not many people fish for it)"),
 				default = defaults.fishing.seaCreatureAlert.carrotKingIsRare,
 				property = config.fishing.seaCreatureAlert::carrotKingIsRare
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.fishing.seaCreatureAlert.announceInPartyChat", "Announce in Party Chat"),
 				tr("nobaaddons.config.fishing.seaCreatureAlert.announceInPartyChat.tooltip", "A chat message will also be sent in party chat when catching a rare creature"),
 				default = defaults.fishing.seaCreatureAlert.announceInPartyChat,
 				property = config.fishing.seaCreatureAlert::announceInPartyChat
-			)
+			) requires enabled
 			cycler(
 				CommonText.Config.NOTIFICATION_SOUND,
 				default = defaults.fishing.seaCreatureAlert.notificationSound,
 				property = config.fishing.seaCreatureAlert::notificationSound
-			)
+			) requires enabled
 		}
 		// endregion
 
 		// region Highlight Thunder Sparks
 		buildGroup(tr("nobaaddons.config.fishing.highlightThunderSparks", "Highlight Thunder Sparks")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.fishing.highlightThunderSparks.enabled,
 				property = config.fishing.highlightThunderSparks::enabled
@@ -96,12 +97,12 @@ object FishingCategory {
 				CommonText.Config.HIGHLIGHT_COLOR,
 				default = defaults.fishing.highlightThunderSparks.highlightColor,
 				property = config.fishing.highlightThunderSparks::highlightColor
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.fishing.highlightThunderSparks.showText", "Show Text"),
 				default = defaults.fishing.highlightThunderSparks.showText,
 				property = config.fishing.highlightThunderSparks::showText
-			)
+			) requires enabled
 		}
 		// endregion
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/InventoryCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/InventoryCategory.kt
@@ -2,14 +2,17 @@ package me.nobaboy.nobaaddons.config.categories
 
 import me.nobaboy.nobaaddons.config.NobaConfig
 import me.nobaboy.nobaaddons.config.NobaConfigUtils
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.availableIf
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.cycler
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.slider
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.tickBox
 import me.nobaboy.nobaaddons.config.UISettings
+import me.nobaboy.nobaaddons.features.inventory.enchants.EnchantmentDisplayMode
 import me.nobaboy.nobaaddons.ui.TextShadow
 import me.nobaboy.nobaaddons.utils.CommonText
 import me.nobaboy.nobaaddons.utils.tr
@@ -162,7 +165,7 @@ object InventoryCategory {
 
 		// region Enchantment Tooltips
 		buildGroup(tr("nobaaddons.config.inventory.enchantmentTooltips", "Enchantment Tooltips")) {
-			boolean(
+			val enabled = boolean(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.modifyTooltips", "Modify Enchant Tooltips"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.modifyTooltips.tooltip", "Reformats the enchantment list on items in a style similar to the same feature from Skyblock Addons"),
 				default = defaults.inventory.enchantmentTooltips.modifyTooltips,
@@ -173,38 +176,38 @@ object InventoryCategory {
 				tr("nobaaddons.config.inventory.enchantmentTooltips.replaceRomanNumerals.tooltip", "Enchantment tiers will be replaced with their number representation instead of the original roman numerals used"),
 				default = defaults.inventory.enchantmentTooltips.replaceRomanNumerals,
 				property = config.inventory.enchantmentTooltips::replaceRomanNumerals
-			)
-			cycler(
+			) requires enabled
+			val display = cycler(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.displayMode", "Display Mode"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.displayMode.tooltip", "Changes how enchantments are displayed on items; Default will follow roughly the same behavior as Hypixel and compact at 6 or more enchants, while Compact will always condense them into as few lines as possible."),
 				default = defaults.inventory.enchantmentTooltips.displayMode,
 				property = config.inventory.enchantmentTooltips::displayMode
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.showDescriptions", "Show Descriptions"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.showDescriptions.tooltip", "Controls whether enchant descriptions will be shown when enchantments aren't compacted (only when Hypixel adds the descriptions); this does not affect enchanted books with a single enchantment, and is not applicable with Compact display mode."),
 				default = defaults.inventory.enchantmentTooltips.showDescriptions,
 				property = config.inventory.enchantmentTooltips::showDescriptions
-			)
+			).availableIf(enabled, display) { display.pendingValue() != EnchantmentDisplayMode.COMPACT && enabled.pendingValue() }
 			boolean(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.showStacking", "Show Stacking Enchant Progress"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.showStacking.tooltip", "Shows the total value (and progress to next tier if applicable) on stacking enchantments like Champion, Expertise, etc."),
 				default = defaults.inventory.enchantmentTooltips.showStackingProgress,
 				property = config.inventory.enchantmentTooltips::showStackingProgress
-			)
+			) requires enabled
 
 			color(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.maxColor", "Max Enchant Color"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.maxColor.tooltip", "The color used for enchantments at their maximum level"),
 				default = defaults.inventory.enchantmentTooltips.maxColor,
 				property = config.inventory.enchantmentTooltips::maxColor
-			)
+			) requires enabled
 			color(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.goodColor", "Good Enchant Color"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.goodColor.tooltip", "The color used for enchantments that are above their max normally obtainable level"),
 				default = defaults.inventory.enchantmentTooltips.goodColor,
 				property = config.inventory.enchantmentTooltips::goodColor
-			)
+			) requires enabled
 			color(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.averageColor", "Max Normally Obtainable Enchant Color"),
 				// if only mc-auto-translations supported splitting strings onto multiple lines :(
@@ -214,19 +217,19 @@ object InventoryCategory {
 				),
 				default = defaults.inventory.enchantmentTooltips.averageColor,
 				property = config.inventory.enchantmentTooltips::averageColor
-			)
+			) requires enabled
 			color(
 				tr("nobaaddons.config.inventory.enchantmentTooltips.badColor", "Bad Enchant Color"),
 				tr("nobaaddons.config.inventory.enchantmentTooltips.badColor.tooltip", "The color used for enchantments that aren't at any of the above tiers"),
 				default = defaults.inventory.enchantmentTooltips.badColor,
 				property = config.inventory.enchantmentTooltips::badColor
-			)
+			) requires enabled
 		}
 		// endregion
 
 		// region Item Pickup Log
 		buildGroup(tr("nobaaddons.config.inventory.itemPickupLog", "Item Pickup Log")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.inventory.itemPickupLog.enabled,
 				property = config.inventory.itemPickupLog::enabled
@@ -239,12 +242,12 @@ object InventoryCategory {
 				default = defaults.inventory.itemPickupLog.timeoutSeconds,
 				property = defaults.inventory.itemPickupLog::timeoutSeconds,
 				format = CommonText.Config::seconds
-			)
+			) requires enabled
 			cycler(
 				tr("nobaaddons.config.inventory.itemPickupLog.style", "Text Style"),
 				default = TextShadow.SHADOW,
 				property = UISettings.itemPickupLog::textShadow
-			)
+			) requires enabled
 		}
 		// endregion
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/MiningCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/MiningCategory.kt
@@ -6,6 +6,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.utils.CommonText
 import me.nobaboy.nobaaddons.utils.tr
 
@@ -13,7 +14,7 @@ object MiningCategory {
 	fun create(defaults: NobaConfig, config: NobaConfig) = NobaConfigUtils.buildCategory(tr("nobaaddons.config.mining", "Mining")) {
 		// region Worm Alert
 		buildGroup(tr("nobaaddons.config.mining.wormAlert", "Worm Alert")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.mining.wormAlert.enabled,
 				property = defaults.mining.wormAlert::enabled
@@ -22,7 +23,7 @@ object MiningCategory {
 				CommonText.Config.ALERT_COLOR,
 				default = defaults.mining.wormAlert.alertColor,
 				property = defaults.mining.wormAlert::alertColor
-			)
+			) requires enabled
 		}
 		// endregion
 
@@ -31,7 +32,7 @@ object MiningCategory {
 			// region Corpses
 			label(tr("nobaaddons.config.mining.glaciteMineshaft.label.corpses", "Corpses"))
 
-			boolean(
+			val locate = boolean(
 				tr("nobaaddons.config.mining.glaciteMineshaft.corpseLocator", "Locate Corpses"),
 				tr("nobaaddons.config.mining.glaciteMineshaft.corpseLocator.tooltip", "Marks corpses with a waypoint when they're in your line of sight"),
 				default = defaults.mining.glaciteMineshaft.corpseLocator,
@@ -42,7 +43,7 @@ object MiningCategory {
 				tr("nobaaddons.config.mining.glaciteMineshaft.autoShareCorpses.tooltip", "Automatically shares the coordinates of the nearest corpse within 5 blocks in party chat"),
 				default = defaults.mining.glaciteMineshaft.autoShareCorpses,
 				property = config.mining.glaciteMineshaft::autoShareCorpses
-			)
+			) requires locate
 			// endregion
 
 			// region Miscellaneous

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/QOLCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/QOLCategory.kt
@@ -5,6 +5,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.slider
 import me.nobaboy.nobaaddons.utils.CommonText
 import me.nobaboy.nobaaddons.utils.TextUtils.buildLiteral
@@ -78,7 +79,7 @@ object QOLCategory {
 		buildGroup(tr("nobaaddons.config.qol.garden", "Garden")) {
 			// region Sensitivity Reducer
 			val lockMouseCommand = buildLiteral("/noba lockmouse") { darkAqua() }
-			boolean(
+			val reduce = boolean(
 				tr("nobaaddons.config.qol.garden.reduceMouseSensitivity", "Reduce Mouse Sensitivity"),
 				tr("nobaaddons.config.qol.garden.reduceMouseSensitivity.tooltip", "Reduces your mouse sensitivity in the Garden while holding a farming tool and on the ground. Your mouse may also be locked with $lockMouseCommand"),
 				default = defaults.qol.garden.reduceMouseSensitivity,
@@ -91,13 +92,13 @@ object QOLCategory {
 				min = 2,
 				max = 10,
 				step = 1
-			)
+			) requires reduce
 			boolean(
 				tr("nobaaddons.config.qol.garden.isDaedalusFarmingTool", "Reduce Sensitivity with Daedalus Axe"),
 				tr("nobaaddons.config.qol.garden.isDaedalusFarmingTool.tooltip", "Daedalus Axe will also be counted as a farming tool while enabled"),
 				default = defaults.qol.garden.isDaedalusFarmingTool,
 				property = config.qol.garden::isDaedalusFarmingTool
-			)
+			) requires reduce
 			boolean(
 				tr("nobaaddons.config.qol.garden.autoUnlockMouseOnTeleport", "Auto Unlock Mouse on Teleport"),
 				tr("nobaaddons.config.qol.garden.autoUnlockMouseOnTeleport.tooltip", "Automatically unlocks your mouse when teleporting more than 5 blocks if locked with $lockMouseCommand"),

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -96,12 +96,6 @@ object UIAndVisualsCategory {
 				property = config.uiAndVisuals.renderingTweaks::hideLightningBolt
 			)
 			boolean(
-				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing", "Hide Other People Fishing"),
-				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing.tooltip", "Hides the fishing bobber of other players"),
-				default = defaults.uiAndVisuals.renderingTweaks.hideOtherPeopleFishing,
-				property = config.uiAndVisuals.renderingTweaks::hideOtherPeopleFishing
-			)
-			boolean(
 				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson", "Remove Front-Facing Third Person"),
 				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson.tooltip", "Removes the front-facing perspective from F5"),
 				default = defaults.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson,

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -2,10 +2,13 @@ package me.nobaboy.nobaaddons.config.categories
 
 import me.nobaboy.nobaaddons.config.NobaConfig
 import me.nobaboy.nobaaddons.config.NobaConfigUtils
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.availableIf
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.boolean
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.button
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.conflicts
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.slider
 import me.nobaboy.nobaaddons.screens.infoboxes.InfoBoxesScreen
 import me.nobaboy.nobaaddons.utils.CommonText
@@ -35,7 +38,7 @@ object UIAndVisualsCategory {
 
 		// region Temporary Waypoints
 		buildGroup(tr("nobaaddons.config.uiAndVisuals.temporaryWaypoints", "Temporary Waypoints")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.uiAndVisuals.temporaryWaypoints.enabled,
 				property = config.uiAndVisuals.temporaryWaypoints::enabled
@@ -44,7 +47,7 @@ object UIAndVisualsCategory {
 				tr("nobaaddons.config.uiAndVisuals.temporaryWaypoints.waypointColor", "Waypoint Color"),
 				default = defaults.uiAndVisuals.temporaryWaypoints.waypointColor,
 				property = config.uiAndVisuals.temporaryWaypoints::waypointColor
-			)
+			) requires enabled
 			slider(
 				tr("nobaaddons.config.uiAndVisuals.temporaryWaypoints.expirationTime", "Expiration Time"),
 				tr("nobaaddons.config.uiAndVisuals.temporaryWaypoints.expirationTime.tooltip", "Sets the duration after which a temporary waypoint disappears"),
@@ -53,13 +56,13 @@ object UIAndVisualsCategory {
 				min = 1,
 				max = 120,
 				step = 1
-			)
+			) requires enabled
 		}
 		// endregion
 
 		// region Etherwarp Helper
 		buildGroup(tr("nobaaddons.config.uiAndVisuals.etherwarpHelper", "Etherwarp Overlay")) {
-			boolean(
+			val enabled = boolean(
 				CommonText.Config.ENABLED,
 				default = defaults.uiAndVisuals.etherwarpHelper.enabled,
 				property = config.uiAndVisuals.etherwarpHelper::enabled
@@ -68,19 +71,19 @@ object UIAndVisualsCategory {
 				CommonText.Config.HIGHLIGHT_COLOR,
 				default = defaults.uiAndVisuals.etherwarpHelper.highlightColor,
 				property = config.uiAndVisuals.etherwarpHelper::highlightColor
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.uiAndVisuals.etherwarpHelper.showFailText", "Show Fail Text"),
 				tr("nobaaddons.config.uiAndVisuals.etherwarpHelper.showFailText.tooltip", "Displays the reason for an Etherwarp failure below the crosshair"),
 				default = defaults.uiAndVisuals.etherwarpHelper.showFailText,
 				property = config.uiAndVisuals.etherwarpHelper::showFailText
-			)
+			) requires enabled
 			boolean(
 				tr("nobaaddons.config.uiAndVisuals.etherwarpHelper.allowOverlayOnAir", "Allow Overlay on Air"),
 				tr("nobaaddons.config.uiAndVisuals.etherwarpHelper.allowOverlayOnAir.tooltip", "Allows the overlay to render on air blocks displaying how far you're allowed to teleport"),
 				default = defaults.uiAndVisuals.etherwarpHelper.allowOverlayOnAir,
 				property = config.uiAndVisuals.etherwarpHelper::allowOverlayOnAir
-			)
+			) requires enabled
 		}
 		// endregion
 
@@ -109,7 +112,7 @@ object UIAndVisualsCategory {
 
 		// region Arm Swing Animation Tweaks
 		buildGroup(tr("nobaaddons.config.uiAndVisuals.swingAnimation", "Arm Swing Animation Tweaks")) {
-			slider(
+			val duration = slider(
 				tr("nobaaddons.config.uiAndVisuals.swingAnimation.swingDuration", "Swing Duration"),
 				tr("nobaaddons.config.uiAndVisuals.swingAnimation.swingDuration.tooltip", "Controls how long your arm swing animation duration is, ignoring all effects like Haste"),
 				default = defaults.uiAndVisuals.swingAnimation.swingDuration,
@@ -130,13 +133,13 @@ object UIAndVisualsCategory {
 				tr("nobaaddons.config.uiAndVisuals.swingAnimation.applyToAllPlayers.tooltip", "If enabled, the above swing duration will also apply to all players, insteada of only yourself"),
 				default = defaults.uiAndVisuals.swingAnimation.applyToAllPlayers,
 				property = config.uiAndVisuals.swingAnimation::applyToAllPlayers,
-			)
+			).availableIf(duration) { duration.pendingValue() > 1 }
 		}
 		// endregion
 
 		// region First Person Item Rendering
 		buildGroup(tr("nobaaddons.config.uiAndVisuals.itemRendering", "First Person Item Rendering")) {
-			boolean(
+			val cancelReequip = boolean(
 				tr("nobaaddons.config.uiAndVisuals.itemRendering.cancelReequip", "Cancel Re-equip Animation"),
 				tr("nobaaddons.config.uiAndVisuals.itemRendering.cancelReequip.tooltip", "Prevents the item update animation from playing entirely, including when switching items"),
 				default = defaults.uiAndVisuals.itemPosition.cancelEquipAnimation,
@@ -147,7 +150,7 @@ object UIAndVisualsCategory {
 				tr("nobaaddons.config.uiAndVisuals.itemRendering.cancelItemUpdate.tooltip", "Prevents the item update animation from playing when your held item is updated"),
 				default = defaults.uiAndVisuals.itemPosition.cancelItemUpdateAnimation,
 				property = config.uiAndVisuals.itemPosition::cancelItemUpdateAnimation
-			)
+			) conflicts cancelReequip
 			boolean(
 				tr("nobaaddons.config.uiAndVisuals.itemRendering.cancelDrinkAnimation", "Cancel Item Consume Animation"),
 				tr("nobaaddons.config.uiAndVisuals.itemRendering.cancelDrinkAnimation.tooltip", "Prevents the item consume animation (such as from drinking potions) from playing"),
@@ -195,18 +198,20 @@ object UIAndVisualsCategory {
 
 		// region Armor Glint Tweaks
 		buildGroup(tr("nobaaddons.config.uiAndVisuals.armorGlints", "Armor Glint Tweaks")) {
-			boolean(
+			val fix = boolean(
 				tr("nobaaddons.config.uiAndVisuals.armorGlints.fixGlints", "Fix Armor Enchant Glints"),
 				tr("nobaaddons.config.uiAndVisuals.armorGlints.fixGlints.tooltip", "It's ${societyIsCrumbling(2019)}. Society has progressed little in the past 20 years. The world is falling apart. Hypixel still has yet to figure out how to consistently add an enchantment glint to armor."),
 				default = defaults.uiAndVisuals.renderingTweaks.fixEnchantedArmorGlint,
 				property = config.uiAndVisuals.renderingTweaks::fixEnchantedArmorGlint
 			)
-			boolean(
+			val remove = boolean(
 				tr("nobaaddons.config.uiAndVisuals.armorGlints.removeGlints", "Remove All Armor Enchant Glints"),
 				tr("nobaaddons.config.uiAndVisuals.armorGlints.removeGlints.tooltip", "Removes enchantment glints from all armor pieces"),
 				default = defaults.uiAndVisuals.renderingTweaks.removeArmorGlints,
 				property = config.uiAndVisuals.renderingTweaks::removeArmorGlints
 			)
+
+			fix.conflicts(remove)
 		}
 		// endregion
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/DungeonsConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/DungeonsConfig.kt
@@ -18,7 +18,7 @@ class DungeonsConfig : ObjectProperty<DungeonsConfig>("dungeons") {
 
 	class HighlightStarredMobs : ObjectProperty<HighlightStarredMobs>("highlightStarredMobs") {
 		var enabled by Property.of<Boolean>("enabled", false)
-		var highlightColor by Property.of("highlightColor", Serializer.color, NobaColor.YELLOW.toColor())
+		var highlightColor by Property.of("highlightColor", Serializer.color, NobaColor.YELLOW)
 		var highlightMode by Property.of("highlightMode", Serializer.enum(), HighlightMode.FILLED_OUTLINE)
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/FishingConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/FishingConfig.kt
@@ -5,6 +5,7 @@ import dev.celestialfault.celestialconfig.Property
 import dev.celestialfault.celestialconfig.Serializer
 import me.nobaboy.nobaaddons.utils.serializers.ExtraSerializers.color
 import me.nobaboy.nobaaddons.core.Rarity
+import me.nobaboy.nobaaddons.utils.NobaColor
 import me.nobaboy.nobaaddons.utils.sound.NotificationSound
 import java.awt.Color
 
@@ -34,7 +35,7 @@ class FishingConfig : ObjectProperty<FishingConfig>("fishing") {
 
 	class HighlightThunderSparks : ObjectProperty<HighlightThunderSparks>("highlightThunderSparks") {
 		var enabled by Property.of<Boolean>("enabled", false)
-		var highlightColor by Property.of("highlightColor", Serializer.color, Color(0x24DDE5))
+		var highlightColor by Property.of("highlightColor", Serializer.color, NobaColor(0x24DDE5))
 		var showText by Property.of<Boolean>("showText", false)
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/InventoryConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/InventoryConfig.kt
@@ -48,10 +48,10 @@ class InventoryConfig : ObjectProperty<InventoryConfig>("inventory") {
 		var displayMode by Property.of("displayMode", Serializer.enum(), EnchantmentDisplayMode.NORMAL)
 		var showDescriptions by Property.of<Boolean>("showDescriptions", false)
 		var showStackingProgress by Property.of<Boolean>("showStackingProgress", false)
-		var maxColor by Property.of("maxColor", Serializer.color, NobaColor.GOLD.toColor())
-		var goodColor by Property.of("goodColor", Serializer.color, NobaColor.GOLD.toColor())
-		var averageColor by Property.of("averageColor", Serializer.color, NobaColor.BLUE.toColor())
-		var badColor by Property.of("badColor", Serializer.color, NobaColor.GRAY.toColor())
+		var maxColor by Property.of("maxColor", Serializer.color, NobaColor.GOLD)
+		var goodColor by Property.of("goodColor", Serializer.color, NobaColor.GOLD)
+		var averageColor by Property.of("averageColor", Serializer.color, NobaColor.BLUE)
+		var badColor by Property.of("badColor", Serializer.color, NobaColor.GRAY)
 	}
 
 	class ItemPickupLog : ObjectProperty<ItemPickupLog>("itemPickupLog") {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/MiningConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/MiningConfig.kt
@@ -13,7 +13,7 @@ class MiningConfig : ObjectProperty<MiningConfig>("mining") {
 
 	class WormAlert : ObjectProperty<WormAlert>("wormAlert") {
 		var enabled by Property.of<Boolean>("enabled", false)
-		var alertColor by Property.of("alertColor", Serializer.color, NobaColor.YELLOW.toColor())
+		var alertColor by Property.of("alertColor", Serializer.color, NobaColor.YELLOW)
 		var notificationSound by Property.of("notificationSound", Serializer.enum(), NotificationSound.DING)
 	}
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
@@ -15,13 +15,13 @@ class UIAndVisualsConfig : ObjectProperty<UIAndVisualsConfig>("uiAndVisuals") {
 
 	class TemporaryWaypoints : ObjectProperty<TemporaryWaypoints>("temporaryWaypoints") {
 		var enabled by Property.of<Boolean>("enabled", false)
-		var waypointColor by Property.of("waypointColor", Serializer.color, NobaColor.YELLOW.toColor())
+		var waypointColor by Property.of("waypointColor", Serializer.color, NobaColor.YELLOW)
 		var expirationTime by Property.of<Int>("expirationTime", 30)
 	}
 
 	class EtherwarpHelper : ObjectProperty<EtherwarpHelper>("etherwarpHelper") {
 		var enabled by Property.of<Boolean>("enabled", false)
-		var highlightColor by Property.of("highlightColor", Serializer.color, NobaColor.BLUE.toColor())
+		var highlightColor by Property.of("highlightColor", Serializer.color, NobaColor.BLUE)
 		var showFailText by Property.of<Boolean>("showFailText", false)
 		var allowOverlayOnAir by Property.of<Boolean>("allowOverlayOnAir", false)
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/migrations.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/migrations.kt
@@ -1,12 +1,15 @@
+// This file intentionally violates this style rule to make the migration application order unquestionably clear.
+@file:Suppress("FunctionName")
+
 package me.nobaboy.nobaaddons.config
 
 import com.google.gson.JsonObject
 
-fun `001_removeYaclVersion`(json: JsonObject) {
+internal fun `001_removeYaclVersion`(json: JsonObject) {
 	json.remove("version")
 }
 
-fun `002_inventoryCategory`(json: JsonObject) {
+internal fun `002_inventoryCategory`(json: JsonObject) {
 	json["uiAndVisuals"]?.asJsonObject?.let { uiAndVisuals ->
 		val inventory = json["inventory"]?.asJsonObject ?: JsonObject().also {
 			json.add("inventory", it)
@@ -27,7 +30,7 @@ fun `002_inventoryCategory`(json: JsonObject) {
 	}
 }
 
-fun `003_renameGlaciteMineshaftShareCorpses`(json: JsonObject) {
+internal fun `003_renameGlaciteMineshaftShareCorpses`(json: JsonObject) {
 	val glaciteMineshaft = json["mining"]?.asJsonObject["glaciteMineshaft"]?.asJsonObject ?: return
 	glaciteMineshaft.add("autoShareCorpses", glaciteMineshaft.remove("autoShareCorpseCoords") ?: return)
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/migrations.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/migrations.kt
@@ -10,23 +10,20 @@ internal fun `001_removeYaclVersion`(json: JsonObject) {
 }
 
 internal fun `002_inventoryCategory`(json: JsonObject) {
-	json["uiAndVisuals"]?.asJsonObject?.let { uiAndVisuals ->
-		val inventory = json["inventory"]?.asJsonObject ?: JsonObject().also {
-			json.add("inventory", it)
+	val uiAndVisuals = json["uiAndVisuals"]?.asJsonObject ?: return
+	val inventory = json["inventory"]?.asJsonObject ?: JsonObject().also { json.add("inventory", it) }
+
+	uiAndVisuals.remove("slotInfo")?.asJsonObject?.let { slotInfo ->
+		slotInfo.remove("enabled")
+		inventory.add("slotInfo", slotInfo)
+	}
+
+	uiAndVisuals.remove("enchantments")?.asJsonObject?.let { enchantments ->
+		enchantments.remove("parseItemEnchants")?.asBoolean?.let { parseItemEnchants ->
+			enchantments.addProperty("modifyTooltips", parseItemEnchants)
 		}
 
-		uiAndVisuals.remove("slotInfo")?.asJsonObject?.let { slotInfo ->
-			slotInfo.remove("enabled")
-			inventory.add("slotInfo", slotInfo)
-		}
-
-		uiAndVisuals.remove("enchantments")?.asJsonObject?.let { enchantments ->
-			enchantments.remove("parseItemEnchants")?.asBoolean?.let { parseItemEnchants ->
-				enchantments.addProperty("modifyTooltips", parseItemEnchants)
-			}
-
-			inventory.add("enchantmentTooltips", enchantments)
-		}
+		inventory.add("enchantmentTooltips", enchantments)
 	}
 }
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
@@ -5,11 +5,10 @@ import dev.celestialfault.celestialconfig.Property
 import dev.celestialfault.celestialconfig.Serializer
 import me.nobaboy.nobaaddons.NobaAddons
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.saveEvery
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.saveOnExit
 import me.nobaboy.nobaaddons.core.fishing.TrophyFishRarity
-import me.nobaboy.nobaaddons.utils.Scheduler
 import me.nobaboy.nobaaddons.utils.serializers.ExtraSerializers.enumMap
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import java.util.EnumMap
 
 object PersistentCache : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("cache.json")) {
@@ -24,11 +23,6 @@ object PersistentCache : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("cache.jso
 	fun init() {
 		safeLoad()
 		saveOnExit()
-		Scheduler.scheduleAsync(15 * 20, repeat = true) {
-			if(dirty) {
-				NobaAddons.LOGGER.info("Saving cached values")
-				save()
-			}
-		}
+		saveEvery(ticks = 15 * 20)
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
@@ -4,6 +4,7 @@ import dev.celestialfault.celestialconfig.AbstractConfig
 import dev.celestialfault.celestialconfig.Property
 import dev.celestialfault.celestialconfig.Serializer
 import me.nobaboy.nobaaddons.NobaAddons
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.core.fishing.TrophyFishRarity
 import me.nobaboy.nobaaddons.utils.Scheduler
 import me.nobaboy.nobaaddons.utils.serializers.ExtraSerializers.enumMap
@@ -20,7 +21,7 @@ object PersistentCache : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("cache.jso
 	var repoCommit by Property.ofNullable<String>("repoCommit")
 
 	fun init() {
-		load()
+		safeLoad()
 		Scheduler.scheduleAsync(15 * 20, repeat = true) {
 			if(dirty) {
 				NobaAddons.LOGGER.info("Saving cached values")

--- a/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/data/PersistentCache.kt
@@ -5,6 +5,7 @@ import dev.celestialfault.celestialconfig.Property
 import dev.celestialfault.celestialconfig.Serializer
 import me.nobaboy.nobaaddons.NobaAddons
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.saveOnExit
 import me.nobaboy.nobaaddons.core.fishing.TrophyFishRarity
 import me.nobaboy.nobaaddons.utils.Scheduler
 import me.nobaboy.nobaaddons.utils.serializers.ExtraSerializers.enumMap
@@ -22,15 +23,12 @@ object PersistentCache : AbstractConfig(NobaAddons.CONFIG_DIR.resolve("cache.jso
 
 	fun init() {
 		safeLoad()
+		saveOnExit()
 		Scheduler.scheduleAsync(15 * 20, repeat = true) {
 			if(dirty) {
 				NobaAddons.LOGGER.info("Saving cached values")
 				save()
 			}
-		}
-		ClientLifecycleEvents.CLIENT_STOPPING.register {
-			// mutable variables (like trophyFish) can't set dirty to true, so we have to also save on shutdown
-			save()
 		}
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/chat/notifications/ChatNotifications.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/chat/notifications/ChatNotifications.kt
@@ -1,5 +1,6 @@
 package me.nobaboy.nobaaddons.features.chat.notifications
 
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.utils.ErrorManager
 import me.nobaboy.nobaaddons.utils.NobaColor
 import me.nobaboy.nobaaddons.utils.StringUtils.cleanFormatting
@@ -24,12 +25,7 @@ object ChatNotifications {
 	}
 
 	fun init() {
-		try {
-			ChatNotificationsConfig.load()
-		} catch(ex: IOException) {
-			ErrorManager.logError("Failed to load chat notifications", ex)
-		}
-
+		ChatNotificationsConfig.safeLoad()
 		ClientReceiveMessageEvents.GAME.register { message, overlay ->
 			if(overlay) return@register
 			onChatMessage(message.string.cleanFormatting())

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/dungeons/HighlightStarredMobs.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/dungeons/HighlightStarredMobs.kt
@@ -45,7 +45,7 @@ object HighlightStarredMobs {
 
 		val player = MCUtils.player ?: return
 
-		val color = config.highlightColor.toNobaColor()
+		val color = config.highlightColor
 		val mode = config.highlightMode
 
 		starredMobs.removeIf { !it.isAlive }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/HighlightThunderSparks.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/HighlightThunderSparks.kt
@@ -41,15 +41,13 @@ object HighlightThunderSparks {
 	private fun renderHighlights(context: WorldRenderContext) {
 		if(!enabled) return
 
-		val color = config.highlightColor.toNobaColor()
-
 		sparks.removeIf { !it.isAlive }
 		sparks.forEach {
 			val vec = it.getNobaVec()
 			val block = vec.roundToBlock().add(y = 1).getBlockStateAt()
 			val throughBlocks = vec.distanceToPlayer() < 6 && block.fluidState != null && block.fluidState.fluid is LavaFluid
 
-			RenderUtils.renderOutlinedFilledBox(context, vec.add(x = -0.5, z = -0.5), color, extraSize = -0.25, throughBlocks = throughBlocks)
+			RenderUtils.renderOutlinedFilledBox(context, vec.add(x = -0.5, z = -0.5), config.highlightColor, extraSize = -0.25, throughBlocks = throughBlocks)
 			if(config.showText && vec.distanceToPlayer() < 10) RenderUtils.renderText(vec.raise(1.25), "Thunder Spark", throughBlocks = throughBlocks)
 		}
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/keybinds/KeyBindsManager.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/keybinds/KeyBindsManager.kt
@@ -3,6 +3,7 @@ package me.nobaboy.nobaaddons.features.keybinds
 import kotlinx.io.IOException
 import me.nobaboy.nobaaddons.api.skyblock.SkyBlockAPI
 import me.nobaboy.nobaaddons.config.NobaConfig
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.features.events.mythological.BurrowWaypoints
 import me.nobaboy.nobaaddons.features.keybinds.impl.KeyBind
 import me.nobaboy.nobaaddons.features.keybinds.impl.NobaKeyBind
@@ -25,13 +26,7 @@ object KeyBindsManager {
 
 	fun init() {
 		gameKeyBinds.forEach(KeyBindingHelper::registerKeyBinding)
-
-		try {
-			KeyBindsConfig.load()
-			commandKeyBinds.addAll(KeyBindsConfig.keyBinds)
-		} catch(ex: IOException) {
-			ErrorManager.logError("Failed to load keybinds", ex)
-		}
+		KeyBindsConfig.safeLoad()
 	}
 
 	fun saveKeyBinds() {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/keybinds/KeyBindsManager.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/keybinds/KeyBindsManager.kt
@@ -5,7 +5,6 @@ import me.nobaboy.nobaaddons.api.skyblock.SkyBlockAPI
 import me.nobaboy.nobaaddons.config.NobaConfig
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.features.events.mythological.BurrowWaypoints
-import me.nobaboy.nobaaddons.features.keybinds.impl.KeyBind
 import me.nobaboy.nobaaddons.features.keybinds.impl.NobaKeyBind
 import me.nobaboy.nobaaddons.utils.CooldownManager
 import me.nobaboy.nobaaddons.utils.ErrorManager
@@ -19,7 +18,7 @@ object KeyBindsManager {
 
 	private val cooldownManager = CooldownManager(100.milliseconds)
 
-	internal val commandKeyBinds = mutableListOf<KeyBind>()
+	internal val commandKeyBinds by KeyBindsConfig::keyBinds
 	private val gameKeyBinds = listOf<NobaKeyBind>(
 		NobaKeyBind(tr("nobaaddons.keyBind.mythologicalRitual.nearestWarp", "Mythological Nearest Warp")) { BurrowWaypoints.useNearestWarp() }
 	)
@@ -31,8 +30,6 @@ object KeyBindsManager {
 
 	fun saveKeyBinds() {
 		try {
-			KeyBindsConfig.keyBinds.clear()
-			KeyBindsConfig.keyBinds.addAll(commandKeyBinds)
 			KeyBindsConfig.save()
 		} catch(ex: IOException) {
 			ErrorManager.logError("Failed to save keybinds", ex)

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/mining/WormAlert.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/mining/WormAlert.kt
@@ -22,7 +22,7 @@ object WormAlert {
 		if(!enabled) return
 
 		if(message == "You hear the sound of something approaching...") {
-			RenderUtils.drawTitle(tr("nobaaddons.mining.wormAlert.spawned", "Worm Spawned!"), config.alertColor.toNobaColor())
+			RenderUtils.drawTitle(tr("nobaaddons.mining.wormAlert.spawned", "Worm Spawned!"), config.alertColor)
 			config.notificationSound.play()
 		}
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/ui/infobox/InfoBoxesManager.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/ui/infobox/InfoBoxesManager.kt
@@ -1,7 +1,7 @@
 package me.nobaboy.nobaaddons.features.ui.infobox
 
-import dev.celestialfault.celestialconfig.migrations.ConfigTooNewException
 import kotlinx.io.IOException
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.safeLoad
 import me.nobaboy.nobaaddons.ui.UIManager
 import me.nobaboy.nobaaddons.utils.ErrorManager
 
@@ -9,13 +9,7 @@ object InfoBoxesManager {
 	val infoBoxes by InfoBoxesConfig::infoBoxes
 
 	fun init() {
-		try {
-			InfoBoxesConfig.load()
-		} catch(ex: IOException) {
-			ErrorManager.logError("Failed to load info boxes", ex)
-		} catch(ex: ConfigTooNewException) {
-			ErrorManager.logError("Failed to load info boxes", ex)
-		}
+		InfoBoxesConfig.safeLoad()
 		recreateUIElements()
 	}
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/visuals/EtherwarpHelper.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/visuals/EtherwarpHelper.kt
@@ -74,7 +74,7 @@ object EtherwarpHelper {
 		targetBlock = validateTargetBlock(world, target)
 		if(targetBlock == ValidationType.TOO_FAR && !config.allowOverlayOnAir) return
 
-		var color = targetBlock?.let { NobaColor.GRAY } ?: config.highlightColor.toNobaColor()
+		var color = targetBlock?.let { NobaColor.GRAY } ?: config.highlightColor
 		RenderUtils.renderOutlinedFilledBox(context, target.blockPos.toNobaVec(), color, throughBlocks = true)
 	}
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/visuals/TemporaryWaypoints.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/visuals/TemporaryWaypoints.kt
@@ -66,7 +66,7 @@ object TemporaryWaypoints {
 		if(!enabled) return
 
 		val cameraPos = context.camera().pos.toNobaVec()
-		val color = config.waypointColor.toNobaColor()
+		val color = config.waypointColor
 
 		waypoints.removeIf { it.expired || it.location.distance(cameraPos) < 5.0 }
 		waypoints.forEach { waypoint ->

--- a/src/main/kotlin/me/nobaboy/nobaaddons/screens/keybinds/KeyBindsListWidget.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/screens/keybinds/KeyBindsListWidget.kt
@@ -1,5 +1,6 @@
 package me.nobaboy.nobaaddons.screens.keybinds
 
+import me.nobaboy.nobaaddons.features.keybinds.KeyBindsConfig
 import me.nobaboy.nobaaddons.features.keybinds.KeyBindsManager
 import me.nobaboy.nobaaddons.features.keybinds.impl.KeyBind
 import me.nobaboy.nobaaddons.utils.CommonText
@@ -26,23 +27,16 @@ class KeyBindsListWidget(
 	y: Int,
 	itemHeight: Int
 ) : ElementListWidget<KeyBindsListWidget.AbstractKeyBindEntry>(client, width, height, y, itemHeight) {
-	private val keyBinds = mutableListOf<KeyBind>()
+	private val keyBinds by KeyBindsConfig::keyBinds
 	var hasChanges = false
 
 	init {
-		KeyBindsManager.commandKeyBinds.forEach {
-			keyBinds.add(it.copy())
-		}
-
 		refreshEntries()
 	}
 
 	fun refreshEntries() {
 		clearEntries()
-		keyBinds.forEachIndexed { index, keyBind ->
-			addEntry(KeyBindEntry(index))
-		}
-
+		keyBinds.forEachIndexed { index, keyBind -> addEntry(KeyBindEntry(index)) }
 		update()
 	}
 
@@ -58,10 +52,7 @@ class KeyBindsListWidget(
 
 	fun saveChanges() {
 		keyBinds.removeIf { it.command.isBlank() }
-		KeyBindsManager.commandKeyBinds.clear()
-		KeyBindsManager.commandKeyBinds.addAll(keyBinds)
 		KeyBindsManager.saveKeyBinds()
-
 		hasChanges = false
 	}
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/utils/TextUtils.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/utils/TextUtils.kt
@@ -65,7 +65,7 @@ object TextUtils {
 	fun MutableText.hoverText(builder: MutableText.() -> Unit): MutableText = hoverText(buildText(builder))
 
 	fun Any?.toText(): MutableText = toString().toText()
-	fun String.toText(): MutableText = if(this.isBlank()) Text.empty() else Text.literal(this)
+	fun String.toText(): MutableText = if(this.isEmpty()) Text.empty() else Text.literal(this)
 	fun String.formatted(vararg formatting: Formatting): MutableText = toText().formatted(*formatting)
 	fun String.styled(styleUpdater: UnaryOperator<Style>): MutableText = toText().styled(styleUpdater)
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/utils/serializers/ExtraSerializers.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/utils/serializers/ExtraSerializers.kt
@@ -3,6 +3,7 @@ package me.nobaboy.nobaaddons.utils.serializers
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
 import dev.celestialfault.celestialconfig.Serializer
+import me.nobaboy.nobaaddons.utils.NobaColor
 import java.awt.Color
 import java.util.EnumMap
 
@@ -13,10 +14,10 @@ object ExtraSerializers {
 	inline fun <reified K : Enum<K>, reified V> Serializer.Companion.enumMap(): Serializer<EnumMap<K, V>> =
 		enumMap(findSerializer<V>())
 
-	val Serializer.Companion.color get() = object : Serializer<Color> {
-		override fun serialize(value: Color): JsonElement = JsonPrimitive(value.rgb)
+	val Serializer.Companion.color get() = object : Serializer<NobaColor> {
+		override fun serialize(value: NobaColor): JsonElement = JsonPrimitive(value.rgb)
 
-		override fun deserialize(element: JsonElement): Color? =
-			if(element is JsonPrimitive && element.isNumber) Color(element.asInt) else null
+		override fun deserialize(element: JsonElement): NobaColor? =
+			if(element is JsonPrimitive && element.isNumber) NobaColor(element.asInt) else null
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,7 @@
     "fabric-api": "*",
     "fabric-language-kotlin": "*",
     "hypixel-mod-api": ">=1.0.1",
-    "yet_another_config_lib_v3": "*"
+    "yet_another_config_lib_v3": ">=3.6.0"
   },
   "recommends": {
     "modmenu": "*"


### PR DESCRIPTION
Allows for making config options more clearly indicate that they require a different config option by means of making them (un)available

Also adds a `safeLoad()` for configs which automatically renames the file if they fail to load for any reason