### PR TITLE
add options to hide hotbar elements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,8 @@ dependencies {
 }
 
 loom {
+	accessWidenerPath = file("../../src/main/resources/nobaaddons.accesswidener")
+
 	runConfigs {
 		removeIf { it.environment == "server" }
 	}

--- a/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
+++ b/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
@@ -1,0 +1,19 @@
+package me.nobaboy.nobaaddons.mixins.render;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import me.nobaboy.nobaaddons.config.NobaConfig;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(InGameHud.class)
+abstract class InGameHudMixin {
+	@WrapWithCondition(method = "renderHealthBar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;drawHeart(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/client/gui/hud/InGameHud$HeartType;IIZZZ)V"))
+	public boolean nobaaddons$hideAbsorptionHearts(InGameHud instance, DrawContext context, InGameHud.HeartType type, int x, int y, boolean hardcore, boolean blinking, boolean half) {
+		if(NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAbsorptionHearts()) {
+			return type != InGameHud.HeartType.ABSORBING;
+		}
+		return true;
+	}
+}

--- a/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
+++ b/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
@@ -1,14 +1,38 @@
 package me.nobaboy.nobaaddons.mixins.render;
 
+//? if <1.21.2 {
+/*import org.spongepowered.asm.mixin.injection.Slice;*/
+//?}
+
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import me.nobaboy.nobaaddons.config.NobaConfig;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.function.Function;
+
 @Mixin(InGameHud.class)
 abstract class InGameHudMixin {
+	//? if >=1.21.2 {
+	@WrapWithCondition(method = "renderAirBubbles", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Ljava/util/function/Function;Lnet/minecraft/util/Identifier;IIII)V"))
+	public boolean nobaaddons$hideAirBubbles(DrawContext instance, Function<Identifier, RenderLayer> renderLayers, Identifier sprite, int x, int y, int width, int height) {
+	//?} else {
+	/*@WrapWithCondition(
+		method = "renderStatusBars",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawGuiTexture(Lnet/minecraft/util/Identifier;IIII)V"),
+		slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;isSubmergedIn(Lnet/minecraft/registry/tag/TagKey;)Z")),
+		require = 2,
+		allow = 2
+	)
+	public boolean nobaaddons$hideAirBubbles(DrawContext instance, Identifier texture, int x, int y, int width, int height) {
+	*///?}
+		return !NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAirBubbles();
+	}
+
 	@WrapWithCondition(method = "renderHealthBar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;drawHeart(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/client/gui/hud/InGameHud$HeartType;IIZZZ)V"))
 	public boolean nobaaddons$hideAbsorptionHearts(InGameHud instance, DrawContext context, InGameHud.HeartType type, int x, int y, boolean hardcore, boolean blinking, boolean half) {
 		if(NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAbsorptionHearts()) {

--- a/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
+++ b/src/main/java/me/nobaboy/nobaaddons/mixins/render/InGameHudMixin.java
@@ -5,6 +5,7 @@ package me.nobaboy.nobaaddons.mixins.render;
 //?}
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import me.nobaboy.nobaaddons.api.skyblock.SkyBlockAPI;
 import me.nobaboy.nobaaddons.config.NobaConfig;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
@@ -30,12 +31,15 @@ abstract class InGameHudMixin {
 	)
 	public boolean nobaaddons$hideAirBubbles(DrawContext instance, Identifier texture, int x, int y, int width, int height) {
 	*///?}
-		return !NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAirBubbles();
+		if(SkyBlockAPI.inSkyBlock()) {
+			return !NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAirBubbles();
+		}
+		return true;
 	}
 
 	@WrapWithCondition(method = "renderHealthBar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;drawHeart(Lnet/minecraft/client/gui/DrawContext;Lnet/minecraft/client/gui/hud/InGameHud$HeartType;IIZZZ)V"))
 	public boolean nobaaddons$hideAbsorptionHearts(InGameHud instance, DrawContext context, InGameHud.HeartType type, int x, int y, boolean hardcore, boolean blinking, boolean half) {
-		if(NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAbsorptionHearts()) {
+		if(SkyBlockAPI.inSkyBlock() && NobaConfig.INSTANCE.getUiAndVisuals().getRenderingTweaks().getHideAbsorptionHearts()) {
 			return type != InGameHud.HeartType.ABSORBING;
 		}
 		return true;

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -8,6 +8,7 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.button
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.conflicts
+import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.slider
 import me.nobaboy.nobaaddons.screens.infoboxes.InfoBoxesScreen
@@ -107,10 +108,18 @@ object UIAndVisualsCategory {
 				default = defaults.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson,
 				property = config.uiAndVisuals.renderingTweaks::removeFrontFacingThirdPerson
 			)
+
+			label(tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hotbarElements", "Hotbar Elements"))
+
 			boolean(
 				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideAbsorptionHearts", "Hide Absorption Hearts"),
 				default = defaults.uiAndVisuals.renderingTweaks.hideAbsorptionHearts,
 				property = config.uiAndVisuals.renderingTweaks::hideAbsorptionHearts
+			)
+			boolean(
+				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideAirBubbles", "Hide Air Bubbles"),
+				default = defaults.uiAndVisuals.renderingTweaks.hideAirBubbles,
+				property = config.uiAndVisuals.renderingTweaks::hideAirBubbles
 			)
 		}
 		// endregion

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -8,7 +8,6 @@ import me.nobaboy.nobaaddons.config.NobaConfigUtils.buildGroup
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.button
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.color
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.conflicts
-import me.nobaboy.nobaaddons.config.NobaConfigUtils.label
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.requires
 import me.nobaboy.nobaaddons.config.NobaConfigUtils.slider
 import me.nobaboy.nobaaddons.screens.infoboxes.InfoBoxesScreen

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -107,6 +107,11 @@ object UIAndVisualsCategory {
 				default = defaults.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson,
 				property = config.uiAndVisuals.renderingTweaks::removeFrontFacingThirdPerson
 			)
+			boolean(
+				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideAbsorptionHearts", "Hide Absorption Hearts"),
+				default = defaults.uiAndVisuals.renderingTweaks.hideAbsorptionHearts,
+				property = config.uiAndVisuals.renderingTweaks::hideAbsorptionHearts
+			)
 		}
 		// endregion
 

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/UIAndVisualsCategory.kt
@@ -108,9 +108,6 @@ object UIAndVisualsCategory {
 				default = defaults.uiAndVisuals.renderingTweaks.removeFrontFacingThirdPerson,
 				property = config.uiAndVisuals.renderingTweaks::removeFrontFacingThirdPerson
 			)
-
-			label(tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hotbarElements", "Hotbar Elements"))
-
 			boolean(
 				tr("nobaaddons.config.uiAndVisuals.renderingTweaks.hideAbsorptionHearts", "Hide Absorption Hearts"),
 				default = defaults.uiAndVisuals.renderingTweaks.hideAbsorptionHearts,

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
@@ -34,6 +34,7 @@ class UIAndVisualsConfig : ObjectProperty<UIAndVisualsConfig>("uiAndVisuals") {
 		var fixEnchantedArmorGlint by Property.of<Boolean>("fixEnchantedArmorGlint", false)
 		var removeArmorGlints by Property.of<Boolean>("removeArmorGlints", false)
 		var hideAbsorptionHearts by Property.of<Boolean>("hideAbsorptionHearts", false)
+		var hideAirBubbles by Property.of<Boolean>("hideAirBubbles", false)
 	}
 
 	class SwingAnimation : ObjectProperty<SwingAnimation>("swingAnimation") {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/UIAndVisualsConfig.kt
@@ -33,6 +33,7 @@ class UIAndVisualsConfig : ObjectProperty<UIAndVisualsConfig>("uiAndVisuals") {
 		var removeFrontFacingThirdPerson by Property.of<Boolean>("removeFrontFacingThirdPerson", false)
 		var fixEnchantedArmorGlint by Property.of<Boolean>("fixEnchantedArmorGlint", false)
 		var removeArmorGlints by Property.of<Boolean>("removeArmorGlints", false)
+		var hideAbsorptionHearts by Property.of<Boolean>("hideAbsorptionHearts", false)
 	}
 
 	class SwingAnimation : ObjectProperty<SwingAnimation>("swingAnimation") {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
       }
     ]
   },
+  "accesswidener": "nobaaddons.accesswidener",
   "mixins": ["nobaaddons.mixins.json"],
   "depends": {
     "minecraft": "$mcdep",

--- a/src/main/resources/nobaaddons.accesswidener
+++ b/src/main/resources/nobaaddons.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v2 named
+
+accessible class net/minecraft/client/gui/hud/InGameHud$HeartType


### PR DESCRIPTION
'hotbar elements' meaning 'literally just absorption hearts & air bubbles'

because skyblocker won't do this, because 'we have bars'.

1.21.1 has not been tested and might explode. ideally not though