### PR TITLE
fix catch timer sometimes not working

### DIFF
--- a/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import me.nobaboy.nobaaddons.api.DebugAPI
 import me.nobaboy.nobaaddons.api.InventoryAPI
@@ -101,16 +100,8 @@ object NobaAddons : ClientModInitializer {
 	val LOGGER: Logger = LogUtils.getLogger()
 	val CONFIG_DIR: Path get() = FabricLoader.getInstance().configDir.resolve(MOD_ID)
 
-	@OptIn(ExperimentalSerializationApi::class)
 	val JSON = Json {
 		ignoreUnknownKeys = true
-		allowStructuredMapKeys = true
-
-		// allow some quality of life
-		allowComments = true
-		allowTrailingComma = true
-
-		// encoding related
 		encodeDefaults = true
 		prettyPrint = true
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/NobaAddons.kt
@@ -45,6 +45,7 @@ import me.nobaboy.nobaaddons.features.events.mythological.InquisitorWaypoints
 import me.nobaboy.nobaaddons.features.fishing.AnnounceSeaCreatures
 import me.nobaboy.nobaaddons.features.fishing.CatchTimer
 import me.nobaboy.nobaaddons.features.fishing.FishingBobberTweaks
+import me.nobaboy.nobaaddons.features.fishing.FixFishHookFieldDesync
 import me.nobaboy.nobaaddons.features.fishing.HotspotWaypoints
 import me.nobaboy.nobaaddons.features.fishing.RevertTreasureMessages
 import me.nobaboy.nobaaddons.features.fishing.SeaCreatureAlert
@@ -208,6 +209,7 @@ object NobaAddons : ClientModInitializer {
 		// endregion
 
 		// region Fishing
+		FixFishHookFieldDesync.init()
 		AnnounceSeaCreatures.init()
 		CatchTimer.init()
 		FishingBobberTweaks.init()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/NobaConfig.kt
@@ -64,7 +64,7 @@ object NobaConfig : AbstractNobaConfig() {
 	}.build().generateScreen(parent)
 }
 
-internal class NobaConfigDefaults : AbstractNobaConfig() {
+private class NobaConfigDefaults : AbstractNobaConfig() {
 	override fun save() {
 		throw UnsupportedOperationException()
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/FishingCategory.kt
@@ -35,6 +35,15 @@ object FishingCategory {
 			booleanController()
 		}
 
+		add({ fishing::fixFishHookFieldDesync }) {
+			name = tr("nobaaddons.config.fishing.fixFishHookFieldDesync", "Fix Fishing Hook Desync")
+			descriptionText = tr(
+				"nobaaddons.config.fishing.fixFishHookFieldDesync.tooltip",
+				"Fixes a desync that can occur if you catch and throw your rod too fast, which is especially noticeable with high ping, which causes the fishing rod texture to appear incorrect."
+			)
+			booleanController()
+		}
+
 		seaCreatureAlert()
 		announceSeaCreatures()
 		bobberTimer()
@@ -108,7 +117,7 @@ object FishingCategory {
 		group(tr("nobaaddons.config.fishing.catchTimer", "Catch Timer")) {
 			val enabled = add({ fishing::catchTimerHudElement }) {
 				name = CommonText.Config.ENABLED
-				descriptionText = tr("nobaaddons.config.fishing.catchTimer.enabled.tooltip", "Moves the catch timer text displayed above your fishing bobber to a HUD element")
+				descriptionText = tr("nobaaddons.config.fishing.catchTimer.enabled.tooltip", "Moves the catch timer text displayed above your fishing bobber to a HUD element\n\nNote that with high ping, you'll want to enable Fix Fishing Hook Desync as well.")
 				booleanController()
 			}
 			add(Binding.generic(TextShadow.SHADOW, UISettings.catchTimer::textShadow, UISettings.catchTimer::textShadow.setter)) {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/FishingConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/FishingConfig.kt
@@ -11,6 +11,7 @@ class FishingConfig {
 	var hideOtherPeopleFishing = false
 	var hotspotWaypoints = false
 	var catchTimerHudElement = false
+	var fixFishHookFieldDesync = true
 
 	@Object val seaCreatureAlert = SeaCreatureAlert()
 	@Object val announceSeaCreatures = AnnounceSeaCreatures()

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/CatchTimer.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/CatchTimer.kt
@@ -3,40 +3,33 @@ package me.nobaboy.nobaaddons.features.fishing
 import me.nobaboy.nobaaddons.api.skyblock.SkyBlockAPI
 import me.nobaboy.nobaaddons.config.NobaConfig
 import me.nobaboy.nobaaddons.config.UISettings
-import me.nobaboy.nobaaddons.events.impl.client.TickEvents
 import me.nobaboy.nobaaddons.events.impl.render.EntityNametagRenderEvents
 import me.nobaboy.nobaaddons.repo.Repo.fromRepo
 import me.nobaboy.nobaaddons.ui.ElementAlignment
 import me.nobaboy.nobaaddons.ui.TextHudElement
 import me.nobaboy.nobaaddons.ui.UIManager
-import me.nobaboy.nobaaddons.utils.EntityUtils
 import me.nobaboy.nobaaddons.utils.MCUtils
 import me.nobaboy.nobaaddons.utils.StringUtils.cleanFormatting
 import me.nobaboy.nobaaddons.utils.tr
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.entity.decoration.ArmorStandEntity
-import net.minecraft.entity.projectile.FishingBobberEntity
 import net.minecraft.text.Text
 
 object CatchTimer {
 	private val config get() = NobaConfig.fishing
 	private val enabled: Boolean get() = config.catchTimerHudElement && SkyBlockAPI.inSkyBlock
 
-	private var hasBobberSpawned: Boolean = false
 	private var timer: ArmorStandEntity? = null
 
 	private val TIMER_REGEX by Regex("^(?:\\d+\\.\\d+|!{3})$").fromRepo("fishing.catch_timer")
 
 	fun init() {
 		EntityNametagRenderEvents.VISIBILITY.register(this::hideTimer)
-		TickEvents.TICK.register {
-			hasBobberSpawned = EntityUtils.getEntities<FishingBobberEntity>().any { it.playerOwner == MCUtils.player }
-		}
 		UIManager.add(CatchTimerHudElement)
 	}
 
 	private fun hideTimer(event: EntityNametagRenderEvents.Visibility) {
-		if(!enabled || !hasBobberSpawned) return
+		if(!enabled || MCUtils.player?.fishHook == null) return
 		val entity = event.entity as? ArmorStandEntity ?: return
 		if(TIMER_REGEX.matchEntire(entity.name.string.cleanFormatting()) == null) return
 		timer = entity

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/CatchTimer.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/CatchTimer.kt
@@ -8,14 +8,15 @@ import me.nobaboy.nobaaddons.repo.Repo.fromRepo
 import me.nobaboy.nobaaddons.ui.ElementAlignment
 import me.nobaboy.nobaaddons.ui.TextHudElement
 import me.nobaboy.nobaaddons.ui.UIManager
+import me.nobaboy.nobaaddons.utils.EntityUtils
 import me.nobaboy.nobaaddons.utils.MCUtils
 import me.nobaboy.nobaaddons.utils.StringUtils.cleanFormatting
 import me.nobaboy.nobaaddons.utils.tr
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.entity.decoration.ArmorStandEntity
+import net.minecraft.entity.projectile.FishingBobberEntity
 import net.minecraft.text.Text
 
-// FIXME: Does not work again if the bobber was cast too fast (consistently shown with a double click)
 object CatchTimer {
 	private val config get() = NobaConfig.fishing
 	private val enabled: Boolean get() = config.catchTimerHudElement && SkyBlockAPI.inSkyBlock
@@ -30,7 +31,7 @@ object CatchTimer {
 	}
 
 	private fun hideTimer(event: EntityNametagRenderEvents.Visibility) {
-		if(!enabled || MCUtils.player?.fishHook == null) return
+		if(!enabled || EntityUtils.getEntities<FishingBobberEntity>().none { it.playerOwner == MCUtils.player }) return
 		val entity = event.entity as? ArmorStandEntity ?: return
 		if(TIMER_REGEX.matchEntire(entity.name.string.cleanFormatting()) == null) return
 		timer = entity

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/FixFishHookFieldDesync.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/FixFishHookFieldDesync.kt
@@ -20,7 +20,7 @@ object FixFishHookFieldDesync {
 		if(!enabled) return
 		val player = MCUtils.player ?: return
 		val bobber = EntityUtils.getEntities<FishingBobberEntity>().firstOrNull { it.playerOwner == player }
-		// using a mixin to FishingBobberEntity#setPlayerOwner to more directly fix this issue is *technically*
+		// using a mixin to FishingBobberEntity#setPlayerFishHook to more directly fix this issue is *technically*
 		// possible, and may be better, but this also works, and takes a lot less effort. therefore, this is good enough.
 		player.fishHook = bobber
 	}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/FixFishHookFieldDesync.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/fishing/FixFishHookFieldDesync.kt
@@ -1,0 +1,27 @@
+package me.nobaboy.nobaaddons.features.fishing
+
+import me.nobaboy.nobaaddons.config.NobaConfig
+import me.nobaboy.nobaaddons.utils.EntityUtils
+import me.nobaboy.nobaaddons.utils.ErrorManager
+import me.nobaboy.nobaaddons.utils.MCUtils
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
+import net.minecraft.entity.projectile.FishingBobberEntity
+
+object FixFishHookFieldDesync {
+	val enabled get() = NobaConfig.fishing.fixFishHookFieldDesync
+
+	fun init() {
+		ClientTickEvents.START_CLIENT_TICK.register {
+			ErrorManager.catching("Fix fishing bobber desync errored", this::onTick)
+		}
+	}
+
+	private fun onTick() {
+		if(!enabled) return
+		val player = MCUtils.player ?: return
+		val bobber = EntityUtils.getEntities<FishingBobberEntity>().firstOrNull { it.playerOwner == player }
+		// using a mixin to FishingBobberEntity#setPlayerOwner to more directly fix this issue is *technically*
+		// possible, and may be better, but this also works, and takes a lot less effort. therefore, this is good enough.
+		player.fishHook = bobber
+	}
+}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/utils/ErrorManager.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/utils/ErrorManager.kt
@@ -110,4 +110,9 @@ object ErrorManager {
 		MCUtils.copyToClipboard(error)
 		MCUtils.chatHud.addMessage(tr("nobaaddons.error.copiedToClipboard", "Copied full error to clipboard, please report it in the Discord"))
 	}
+
+	inline fun <R> catching(errorMessage: String, exec: () -> R): Result<R> =
+		runCatching(exec).onFailure {
+			logError(errorMessage, it)
+		}
 }


### PR DESCRIPTION
if you catch and immediately re-throw your rod fast enough the game can sometimes leave the PlayerEntity#fishHook field as null, despite the fact that you actually have a bobber spawned

so, the simple fix is to just compare *every* spawned bobber entity, as this is much more reliable (and is what the fishing line rendering uses)