### PR TITLE
add optional top-level aliases for some commands

### DIFF
--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/HypixelChatCommandMocks.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/HypixelChatCommandMocks.kt
@@ -1,5 +1,6 @@
 package me.nobaboy.nobaaddons.commands
 
+import com.mojang.brigadier.CommandDispatcher
 import dev.celestialfault.commander.annotations.Command
 import dev.celestialfault.commander.annotations.Greedy
 import me.nobaboy.nobaaddons.commands.impl.CommandUtil
@@ -8,20 +9,26 @@ import me.nobaboy.nobaaddons.utils.MCUtils
 import me.nobaboy.nobaaddons.utils.annotations.UntranslatedMessage
 import me.nobaboy.nobaaddons.utils.chat.ChatUtils
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
 import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.command.CommandRegistryAccess
 
 @OptIn(UntranslatedMessage::class)
 internal object HypixelChatCommandMocks {
 	private val commander by CommandUtil::commander
 
-	internal fun init() {
-		if(!FabricLoader.getInstance().isDevelopmentEnvironment) return
-		ClientCommandRegistrationCallback.EVENT.register { dispatcher, _ ->
-			if(!MCUtils.client.isInSingleplayer) return@register
-			commander.register(NobaClientCommand(::guildChat, this), dispatcher)
-			commander.register(NobaClientCommand(::partyChat, this), dispatcher)
-			commander.register(NobaClientCommand(::message, this), dispatcher)
+	init {
+		if(FabricLoader.getInstance().isDevelopmentEnvironment) {
+			ClientCommandRegistrationCallback.EVENT.register(this::register)
 		}
+	}
+
+	private fun register(dispatcher: CommandDispatcher<FabricClientCommandSource>, @Suppress("unused") registryAccess: CommandRegistryAccess) {
+		if(!MCUtils.client.isInSingleplayer) return
+		commander.register(NobaClientCommand(::guildChat, this), dispatcher)
+		commander.register(NobaClientCommand(::partyChat, this), dispatcher)
+		commander.register(NobaClientCommand(::message, this), dispatcher)
 	}
 
 	@Command("gc")

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/InstanceCommands.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/InstanceCommands.kt
@@ -1,0 +1,63 @@
+package me.nobaboy.nobaaddons.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap
+import me.nobaboy.nobaaddons.commands.impl.Context
+import me.nobaboy.nobaaddons.utils.TextUtils.darkGray
+import me.nobaboy.nobaaddons.utils.chat.ChatUtils
+import me.nobaboy.nobaaddons.utils.tr
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+
+object InstanceCommands {
+	private val floors = Int2ObjectArrayMap<String>(7).apply {
+		put(1, "one")
+		put(2, "two")
+		put(3, "three")
+		put(4, "four")
+		put(5, "five")
+		put(6, "six")
+		put(7, "seven")
+	}
+
+	private val kuudraTiers = Int2ObjectArrayMap<String>(5).apply {
+		put(1, "normal")
+		put(2, "hot")
+		put(3, "burning")
+		put(4, "fiery")
+		put(5, "infernal")
+	}
+
+	private val INSTANCE_COMMANDS = buildMap {
+		for(floor in 1..7) {
+			put("f$floor", "catacombs_floor_${floors[floor]}")
+			put("m$floor", "master_catacombs_floor_${floors[floor]}")
+		}
+		for(tier in 1..5) {
+			put("t$tier", "kuudra_${kuudraTiers[tier]}")
+		}
+	}
+
+	internal fun register(dispatcher: CommandDispatcher<FabricClientCommandSource>) {
+		// we unfortunately have to build these commands ourselves, as there's no way to use commander and still
+		// be able to get the command name from the provided context; at least, not without doing some ugly
+		// hacky workarounds (which would still be more work than just building the commands ourselves)
+		INSTANCE_COMMANDS.forEach { command, instance ->
+			dispatcher.register(ClientCommandManager.literal(command).executes(joinInstanceCommand(command, instance)))
+		}
+	}
+
+	fun joinInstance(name: String) {
+		joinInstance(name, INSTANCE_COMMANDS[name.lowercase()] ?: return)
+	}
+
+	fun joinInstance(name: String, instance: String) {
+		ChatUtils.addMessage(tr("nobaaddons.commands.joinInstance", "Joining ${name.uppercase()}").darkGray())
+		ChatUtils.queueCommand("joininstance $instance")
+	}
+
+	private fun joinInstanceCommand(name: String, instance: String): (Context) -> Int = {
+		joinInstance(name, instance)
+		0
+	}
+}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/NobaCommand.kt
@@ -34,7 +34,8 @@ import net.minecraft.util.Formatting
 object NobaCommand {
 	init {
 		CommandUtil.registerRoot(this)
-		HypixelChatCommandMocks.init()
+		HypixelChatCommandMocks
+		ShortCommands
 	}
 
 	@RootCommand

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/ShortCommands.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/ShortCommands.kt
@@ -1,0 +1,30 @@
+package me.nobaboy.nobaaddons.commands
+
+import com.mojang.brigadier.CommandDispatcher
+import me.nobaboy.nobaaddons.commands.impl.CommandUtil
+import me.nobaboy.nobaaddons.commands.impl.NobaShortClientCommand
+import me.nobaboy.nobaaddons.config.NobaConfig
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
+import net.minecraft.command.CommandRegistryAccess
+
+object ShortCommands {
+	private val commander by CommandUtil::commander
+	private val config by NobaConfig.general::shortCommands
+
+	init {
+		ClientCommandRegistrationCallback.EVENT.register(this::register)
+	}
+
+	private fun register(dispatcher: CommandDispatcher<FabricClientCommandSource>, @Suppress("unused") registryAccess: CommandRegistryAccess) {
+		if(config.registerCalculateCommands) {
+			commander.register(NobaShortClientCommand("calccata", CalculateCommands::cata, CalculateCommands), dispatcher)
+			commander.register(NobaShortClientCommand("calcpet", CalculateCommands::pet, CalculateCommands), dispatcher)
+			commander.register(NobaShortClientCommand("calcskill", CalculateCommands::skill, CalculateCommands), dispatcher)
+			commander.register(NobaShortClientCommand("calctax", CalculateCommands::tax, CalculateCommands), dispatcher)
+		}
+		if(config.registerInstanceCommands) {
+			InstanceCommands.register(dispatcher)
+		}
+	}
+}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/impl/NobaClientCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/impl/NobaClientCommand.kt
@@ -9,7 +9,7 @@ import me.nobaboy.nobaaddons.NobaAddons
 import me.nobaboy.nobaaddons.utils.ErrorManager
 import kotlin.reflect.KFunction
 
-class NobaClientCommand(function: KFunction<*>, instance: Any?) : ClientCommand(function, instance) {
+open class NobaClientCommand(function: KFunction<*>, instance: Any?) : ClientCommand(function, instance) {
 	override fun onError(error: Throwable) {
 		if(error is CommandSyntaxException) throw error
 		ErrorManager.logError("Command '$name' threw an unhandled error", error, ignorePreviousErrors = true)

--- a/src/main/kotlin/me/nobaboy/nobaaddons/commands/impl/NobaShortClientCommand.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/commands/impl/NobaShortClientCommand.kt
@@ -1,0 +1,10 @@
+package me.nobaboy.nobaaddons.commands.impl
+
+import kotlin.reflect.KFunction
+
+class NobaShortClientCommand(
+	override val name: String,
+	function: KFunction<*>,
+	instance: Any?,
+	override val aliases: List<String> = emptyList(),
+) : NobaClientCommand(function, instance)

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/GeneralCategory.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/categories/GeneralCategory.kt
@@ -1,6 +1,9 @@
 package me.nobaboy.nobaaddons.config.categories
 
+import dev.isxander.yacl3.api.ConfigCategory
 import me.nobaboy.nobaaddons.config.util.*
+import me.nobaboy.nobaaddons.utils.TextUtils.aqua
+import me.nobaboy.nobaaddons.utils.TextUtils.toText
 import me.nobaboy.nobaaddons.utils.tr
 
 object GeneralCategory {
@@ -27,6 +30,26 @@ object GeneralCategory {
 			name = tr("nobaaddons.config.general.compactModMessagePrefix", "Compact Mod Message Prefix")
 			descriptionText = tr("nobaaddons.config.general.compactModMessagePrefix.tooltip", "Chat messages added by the mod will use a shorter prefix when enabled")
 			booleanController()
+		}
+
+		commands()
+	}
+
+	private fun ConfigCategory.Builder.commands() {
+		group(tr("nobaaddons.config.general.commands", "Commands")) {
+			add({ general.shortCommands::registerCalculateCommands }) {
+				name = tr("nobaaddons.config.general.commands.registerCalculateCommands", "Calculate Commands")
+				val nobaCalc = "/nobaaddons calculate".toText().aqua()
+				descriptionText = tr("nobaaddons.config.general.commands.registerCalculateCommands.tooltip", "Registers shorter aliases for the $nobaCalc commands like /calcpet, /calcskill, etc.")
+				booleanController()
+				worldSwitchRequired()
+			}
+			add({ general.shortCommands::registerInstanceCommands }) {
+				name = tr("nobaaddons.config.general.commands.registerInstanceCommands", "Instance Commands")
+				descriptionText = tr("nobaaddons.config.general.commands.registerInstanceCommands.tooltip", "Registers commands to join instanced islands like Catacombs (e.g. /f7), Master Mode Catacombs (e.g. /m6), and Kuudra (e.g. /t5)")
+				booleanController()
+				worldSwitchRequired()
+			}
 		}
 	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/GeneralConfig.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/configs/GeneralConfig.kt
@@ -1,8 +1,17 @@
 package me.nobaboy.nobaaddons.config.configs
 
+import dev.celestialfault.histoire.Object
+
 class GeneralConfig {
+	@Object val shortCommands = ShortCommands()
+
 	var wikiCommandAutoOpen = false
 	var allowKeybindsOutsideSkyBlock = false
 	var updateNotifier = true
 	var compactModMessagePrefix = false
+
+	class ShortCommands {
+		var registerInstanceCommands = false
+		var registerCalculateCommands = false
+	}
 }

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.widget.ButtonWidget
 import net.minecraft.screen.ScreenTexts
 
+// hijacking the ConfirmScreen implementation ~~for fame and profit~~ so that i dont need to write this screen myself
 private class WorldSwitchRequired(private val parent: Screen?) : ConfirmScreen(
 	{},
 	tr("nobaaddons.screen.relogRequired", "Config option requires relog!").red().bold(),

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
@@ -14,7 +14,7 @@ import net.minecraft.screen.ScreenTexts
 private class WorldSwitchRequired(private val parent: Screen?) : ConfirmScreen(
 	{},
 	tr("nobaaddons.screen.relogRequired", "Config option requires relog!").red().bold(),
-	tr("nobaaddons.screen.relogRequired.text", "One or more options that you reconnect or switch islands to apply the changes"),
+	tr("nobaaddons.screen.relogRequired.text", "One or more options require that you reconnect or switch islands to apply the changes"),
 	ScreenTexts.EMPTY,
 	ScreenTexts.EMPTY,
 ) {

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/util/flags.kt
@@ -1,0 +1,36 @@
+package me.nobaboy.nobaaddons.config.util
+
+import dev.isxander.yacl3.api.OptionFlag
+import me.nobaboy.nobaaddons.utils.MCUtils
+import me.nobaboy.nobaaddons.utils.TextUtils.bold
+import me.nobaboy.nobaaddons.utils.TextUtils.red
+import me.nobaboy.nobaaddons.utils.tr
+import net.minecraft.client.gui.screen.ConfirmScreen
+import net.minecraft.client.gui.screen.Screen
+import net.minecraft.client.gui.widget.ButtonWidget
+import net.minecraft.screen.ScreenTexts
+
+private class WorldSwitchRequired(private val parent: Screen?) : ConfirmScreen(
+	{},
+	tr("nobaaddons.screen.relogRequired", "Config option requires relog!").red().bold(),
+	tr("nobaaddons.screen.relogRequired.text", "One or more options that you reconnect or switch islands to apply the changes"),
+	ScreenTexts.EMPTY,
+	ScreenTexts.EMPTY,
+) {
+	override fun addButtons(y: Int) {
+		addButton(ButtonWidget.builder(ScreenTexts.OK) { MCUtils.client.setScreen(parent) }.dimensions(this.width / 2 - 155, y, 300, 20).build())
+	}
+}
+
+private inline fun openScreenFlag(crossinline factory: (Screen?) -> Screen) =
+	OptionFlag { MCUtils.client.setScreen(factory(MCUtils.client.currentScreen)) }
+
+/**
+ * Adds an [OptionFlag] telling the user that they must relog or switch islands to apply the changes
+ *
+ * This method does nothing if the user is not currently in a world.
+ */
+fun OptionBuilder<*>.worldSwitchRequired() {
+	if(MCUtils.world == null) return
+	flags.add(openScreenFlag(::WorldSwitchRequired))
+}

--- a/src/main/kotlin/me/nobaboy/nobaaddons/config/util/option.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/config/util/option.kt
@@ -7,6 +7,7 @@ import dev.isxander.yacl3.api.Option
 import dev.isxander.yacl3.api.OptionAddable
 import dev.isxander.yacl3.api.OptionDescription
 import dev.isxander.yacl3.api.OptionEventListener
+import dev.isxander.yacl3.api.OptionFlag
 import dev.isxander.yacl3.api.controller.ControllerBuilder
 import dev.isxander.yacl3.gui.YACLScreen
 import me.nobaboy.nobaaddons.config.AbstractNobaConfig
@@ -26,6 +27,7 @@ class OptionBuilder<T> internal constructor(val binding: Binding<T>) {
 	var description: OptionDescription? = null
 
 	lateinit var controller: (Option<T>) -> ControllerBuilder<T>
+	val flags = mutableListOf<OptionFlag>()
 
 	var requirement: OptionRequirement? = null
 
@@ -45,6 +47,7 @@ class OptionBuilder<T> internal constructor(val binding: Binding<T>) {
 			description?.let(::description)
 			binding(binding)
 			controller(controller)
+			flags(flags)
 		}.build()
 
 		requirement?.let(option::require)

--- a/src/main/kotlin/me/nobaboy/nobaaddons/features/chat/chatcommands/impl/party/JoinInstanceCommands.kt
+++ b/src/main/kotlin/me/nobaboy/nobaaddons/features/chat/chatcommands/impl/party/JoinInstanceCommands.kt
@@ -1,32 +1,11 @@
 package me.nobaboy.nobaaddons.features.chat.chatcommands.impl.party
 
-import me.nobaboy.nobaaddons.api.PartyAPI
-import me.nobaboy.nobaaddons.features.chat.chatcommands.ChatCommand
+import me.nobaboy.nobaaddons.commands.InstanceCommands
 import me.nobaboy.nobaaddons.features.chat.chatcommands.ChatContext
-import me.nobaboy.nobaaddons.utils.chat.ChatUtils
-import me.nobaboy.nobaaddons.utils.tr
 import net.hypixel.modapi.packet.impl.clientbound.ClientboundPartyInfoPacket
 import kotlin.time.Duration.Companion.seconds
 
 class JoinInstanceCommands : AbstractPartyChatCommand(2.seconds) {
-	private val floors = mapOf(
-		1 to "one",
-		2 to "two",
-		3 to "three",
-		4 to "four",
-		5 to "five",
-		6 to "six",
-		7 to "seven"
-	)
-
-	private val kuudraTiers = mapOf(
-		1 to "normal",
-		2 to "hot",
-		3 to "burning",
-		4 to "fiery",
-		5 to "infernal"
-	)
-
 	override val enabled: Boolean = config.party.joinInstanced
 	override val requireClientPlayerIs = ClientboundPartyInfoPacket.PartyRole.LEADER
 
@@ -39,17 +18,7 @@ class JoinInstanceCommands : AbstractPartyChatCommand(2.seconds) {
 	override val usage: String = "f(1-7), m(1-7), t(1-5)"
 
 	override suspend fun run(ctx: ChatContext) {
-		val type = ctx.command.first().lowercase()
-		val tier = ctx.command.last().toString().toInt()
-
-		val instanceName = when(type) {
-			"f", "m" -> "${if(type == "m") "master_" else ""}catacombs_floor_${floors[tier]}"
-			"t" -> "kuudra_${kuudraTiers[tier]}"
-			else -> throw MatchException(null, null)
-		}
-
-		ChatUtils.addMessage(tr("nobaaddons.chat.partyCommands.joiningInstance", "Joining ${type.uppercase()}$tier"))
-		ChatUtils.queueCommand("joininstance $instanceName")
+		InstanceCommands.joinInstance(ctx.command)
 		startCooldown()
 	}
 }


### PR DESCRIPTION
these are locked behind config options because to be quite honest i dont know how the game reacts to conflicting top-level commands, and id rather not have these on by default in case the game implodes over it.

hopefully it doesnt though. but still not something i feel like testing either way, to be honest.